### PR TITLE
add additional selector segment to override Bootstrap styles

### DIFF
--- a/app/assets/stylesheets/effective_datatables/_overrides.scss.erb
+++ b/app/assets/stylesheets/effective_datatables/_overrides.scss.erb
@@ -26,7 +26,7 @@ table.dataTable thead > tr > th.sorting {
   padding-right: 18px;
 }
 
-table.dataTable thead th {
+table.dataTable thead tr th {
   text-align: left;
   vertical-align: top;
   border-bottom: none;


### PR DESCRIPTION
I'm on Bootstrap v3.3.5 and these styles weren't being applied since Bootstrap's selector is more qualified.