### PR TITLE
Make total_records work with any database adapter by using ActiveRecord::Result

### DIFF
--- a/app/models/effective/datatable.rb
+++ b/app/models/effective/datatable.rb
@@ -124,9 +124,9 @@ module Effective
         if active_record_collection?
           if collection_class.connection.respond_to?(:unprepared_statement)
             collection_sql = collection_class.connection.unprepared_statement { collection.to_sql }
-            (collection_class.connection.execute("SELECT COUNT(*) FROM (#{collection_sql}) AS datatables_total_count").first.values.first rescue 1).to_i
+            (collection_class.connection.exec_query("SELECT COUNT(*) FROM (#{collection_sql}) AS datatables_total_count").rows[0][0] rescue 1).to_i
           else
-            (collection_class.connection.execute("SELECT COUNT(*) FROM (#{collection.to_sql}) AS datatables_total_count").first.values.first rescue 1).to_i
+            (collection_class.connection.exec_query("SELECT COUNT(*) FROM (#{collection.to_sql}) AS datatables_total_count").rows[0][0] rescue 1).to_i
           end
         else
           collection.size


### PR DESCRIPTION
Here is a PR to fix issue #21 

I recommend removing the inline rescue, but I don't know why it's there so I left it alone :)

I did not run tests yet because I cannot bundle install, see issue #22 

I've tested this on postgres and mysql and it worked on my end.

Please let me know what you think.

Thanks!