### PR TITLE
Rescue just the AccessDenied exception

### DIFF
--- a/app/helpers/effective_datatables_helper.rb
+++ b/app/helpers/effective_datatables_helper.rb
@@ -7,8 +7,8 @@ module EffectiveDatatablesHelper
     datatable.view ||= self
 
     begin
-      EffectiveDatatables.authorized?(controller, :index, datatable.collection_class) || raise('unauthorized')
-    rescue => e
+      EffectiveDatatables.authorized?(controller, :index, datatable.collection_class) || raise(Effective::AccessDenied)
+    rescue Effective::AccessDenied => e
       return content_tag(:p, "You are not authorized to view this datatable. (cannot :index, #{datatable.collection_class})")
     end
 
@@ -23,8 +23,8 @@ module EffectiveDatatablesHelper
     datatable.simple = true
 
     begin
-      EffectiveDatatables.authorized?(controller, :index, datatable.collection_class) || raise('unauthorized')
-    rescue => e
+      EffectiveDatatables.authorized?(controller, :index, datatable.collection_class) || raise(Effective::AccessDenied)
+    rescue Effective::AccessDenied => e
       return content_tag(:p, "You are not authorized to view this datatable. (cannot :index, #{datatable.collection_class})})")
     end
 


### PR DESCRIPTION
Rescue just the AccessDenied exception, otherwise we will not be able to see other errors. 

I was having an error inside the custom authorization method and I couldn't see the actual error, just a 'access denied' message in lieu of the table. This pull requests makes it so that it will only output the access denied message if the access was actually denied, letting any other exception flow up.