### PR TITLE
Fixes issue with unselectable checkbox

### DIFF
--- a/app/assets/stylesheets/effective_datatables/_overrides.scss.erb
+++ b/app/assets/stylesheets/effective_datatables/_overrides.scss.erb
@@ -49,7 +49,6 @@ table.dataTable.sort-hidden thead .sorting_desc { background-image: none; }
 
 // Filter bar
 table.dataTable .form-group { width: 100%; margin-left: 0px; margin-right: 0px; }
-table.dataTable input { width: 100%; }
 table.dataTable select { width: 100%; }
 table.dataTable .form-control { width: 100%;  }
 table.dataTable .form-group.datatable_filter_bulk_actions { margin-left: 4px; }


### PR DESCRIPTION
Hi,

So I created a bulk_actions_column in my datatables but I noticed that the checkbox for selecting all check checkboxes was not selectable. 

I reproduced this issue here:
https://github.com/Nerian/example-effective-datatables-bulk

I tracked down the issue to:
https://github.com/code-and-effect/effective_datatables/compare/master...Nerian:fix_bulk_action_input?expand=1#diff-401a9fbad72211af69e9581dfba83968L52

With this line in effect, the checkbox will not be selectable. When I remove that line, the checkbox works as expected. Not sure why it glitches, but this fixes it. I am using Chrome.
