### PR TITLE
Fix filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,8 @@ filters do
   filter :start_date, Time.zone.now-3.months, required: true
   filter :end_date, nil, parse: -> { |term| Time.zone.local(term).end_of_day }
   filter :user, current_user, as: :select, collection: User.all
+  filter :year, 2018, as: :select, collection: [2018, 2017], label: false, include_blank: false
+  filter :reports, '2018', as: :grouped_select, collection: [['Years', [['2017', '2017'], ['2018', '2018']]], ['Months', [['January', '1'], ['February', '2']]]], group_method: :last
 end
 ```
 

--- a/app/models/effective/effective_datatable/dsl/filters.rb
+++ b/app/models/effective/effective_datatable/dsl/filters.rb
@@ -15,7 +15,7 @@ module Effective
             name: name.to_sym,
             parse: parse,
             required: required,
-            input_html: input_html
+            input_html: input_html.merge({ value: value })
           }
         end
 

--- a/app/models/effective/effective_datatable/dsl/filters.rb
+++ b/app/models/effective/effective_datatable/dsl/filters.rb
@@ -11,7 +11,7 @@ module Effective
           datatable._filters[name.to_sym] = {
             value: value,
             as: as,
-            label: label || name.to_s.titleize,
+            label: label || (label == false ? false : name.to_s.titleize),
             name: name.to_sym,
             parse: parse,
             required: required,

--- a/app/views/effective/datatables/_filters.html.haml
+++ b/app/views/effective/datatables/_filters.html.haml
@@ -13,6 +13,7 @@
       .effective-datatables-filters-inputs
         - datatable._filters.each do |name, opts|
           = form.input name, label: opts[:label], required: false, value: datatable.state[:filter][name],
+            selected: datatable.state[:filter][name],
             as: opts[:as],
             collection: opts[:input_html].delete(:collection),
             multiple: opts[:input_html].delete(:multiple),

--- a/app/views/effective/datatables/_filters.html.haml
+++ b/app/views/effective/datatables/_filters.html.haml
@@ -17,6 +17,11 @@
             as: opts[:as],
             collection: opts[:input_html].delete(:collection),
             multiple: opts[:input_html].delete(:multiple),
+            include_blank: opts[:input_html].delete(:include_blank),
+            group_method: opts[:input_html].delete(:group_method),
+            group_label_method: opts[:input_html].delete(:group_label_method),
+            value_method: opts[:input_html].delete(:value_method),
+            label_method: opts[:input_html].delete(:label_method),
             input_html: (({name: ''} unless datatable._filters_form_required?) || {}).merge(opts[:input_html]),
             input_js: ({ placeholder: ''} if opts[:as] == :effective_select),
             wrapper_html: {class: 'form-group-sm'}


### PR DESCRIPTION
Hi,

This fixes:  https://github.com/code-and-effect/effective_datatables/issues/66

Changes:

* Add option to disable labels for a filter:   `label: false`.
* When there is a default value for a filter this value is shown in the html. If it is a collection then the default value is selected.
* Add support for `include_blank`.
* Add support for option for grouped collections: `group_method`, `group_label_method`, `value_method`, `label_method`
