### PR TITLE
better cookie_param

### DIFF
--- a/app/controllers/effective/datatables_controller.rb
+++ b/app/controllers/effective/datatables_controller.rb
@@ -24,7 +24,7 @@ module Effective
     private
 
     def find_datatable(id)
-      id = id.to_s.gsub(/--?\d+\z/, '')
+      id = id.to_s.gsub(/-\d+\z/, '').gsub('-', '/')
       id.classify.safe_constantize || id.classify.pluralize.safe_constantize
     end
 

--- a/app/models/effective/effective_datatable/cookie.rb
+++ b/app/models/effective/effective_datatable/cookie.rb
@@ -17,7 +17,7 @@ module Effective
       end
 
       def cookie_param
-        [self.class, attributes].hash.to_s.last(12)
+        [self.class, attributes].hash.abs.to_s.last(12) # Not guaranteed to be 12 long
       end
 
       private


### PR DESCRIPTION
Hey this adds ontop of @KoenDierckx PR

I tweaked that regex, and put back the gsub. 

Realizing that `.hash` can be a number of any length, not necessarily 12+ is the real fix here.  Also using `.abs` to get rid of a duplicate `-` seems safe enough.

Thanks for the better regex, I tested this with an ID like "skype_users_datatable-40537094" @eleos and "what works on my machine",  "id"=>"admin-users_datatable-33870247"