### PR TITLE
Fixes issue with 'helper' method not been available

### DIFF
--- a/lib/effective_datatables/engine.rb
+++ b/lib/effective_datatables/engine.rb
@@ -7,9 +7,8 @@ module EffectiveDatatables
     # Include Helpers to base application
     initializer 'effective_datatables.action_controller' do |app|
       ActiveSupport.on_load :action_controller do
-        helper EffectiveDatatablesHelper
-        helper EffectiveDatatablesPrivateHelper
-
+        ActionController::Base.send :include, ::EffectiveDatatablesHelper
+        ActionController::Base.send :include, ::EffectiveDatatablesPrivateHelper
         ActionController::Base.send :include, ::EffectiveDatatablesControllerHelper
       end
     end


### PR DESCRIPTION
Hi,

I am having this error:

```
NoMethodError:
  undefined method `helper' for ActionController::API:Class
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/effective_datatables-4.3.13/lib/effective_datatables/engine.rb:10:in `block (2 levels) in <class:Engine>'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:71:in `instance_eval'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:71:in `block in execute_hook'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:51:in `each'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/actionpack-5.2.1.1/lib/action_controller/api.rb:147:in `<class:API>'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/actionpack-5.2.1.1/lib/action_controller/api.rb:89:in `<module:ActionController>'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/actionpack-5.2.1.1/lib/action_controller/api.rb:7:in `<top (required)>'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/dependencies.rb:287:in `require'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/dependencies.rb:287:in `block in require'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/dependencies.rb:253:in `load_dependency'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/activesupport-5.2.1.1/lib/active_support/dependencies.rb:287:in `require'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/sorcery-0.13.0/lib/sorcery/engine.rb:13:in `block in <class:Engine>'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/railties-5.2.1.1/lib/rails/initializable.rb:32:in `instance_exec'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/railties-5.2.1.1/lib/rails/initializable.rb:32:in `run'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/railties-5.2.1.1/lib/rails/initializable.rb:61:in `block in run_initializers'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/railties-5.2.1.1/lib/rails/initializable.rb:60:in `run_initializers'
# /Users/Nerian/.rvm/gems/ruby-2.5.3/gems/railties-5.2.1.1/lib/rails/application.rb:361:in `initialize!'
# ./config/environment.rb:5:in `<top (required)>'
# ./spec/rails_helper.rb:6:in `require'
# ./spec/rails_helper.rb:6:in `<top (required)>'
# ./spec/interactors/account/join_spec.rb:1:in `require'
# ./spec/interactors/account/join_spec.rb:1:in `<top (required)>'
```

And I tracked it down to some kind of issue with the `helper` method and `Sorcery`. This PR fixes it.