### PR TITLE
This makes effective datatable work for subdomains too

### DIFF
--- a/app/models/effective/effective_datatable/cookie.rb
+++ b/app/models/effective/effective_datatable/cookie.rb
@@ -56,7 +56,7 @@ module Effective
           @dt_cookie.shift((@dt_cookie.length / 3) + 1)
         end
 
-        view.cookies.signed['_effective_dt'] = Base64.encode64(Marshal.dump(@dt_cookie))
+        view.cookies.signed['_effective_dt'] = { value: Base64.encode64(Marshal.dump(@dt_cookie)), domain: :all, tld_length: 2 }
       end
 
       def cookie_payload


### PR DESCRIPTION
Hi,

I an app that uses subdomains for client. Something like this:

client1.my-domain.com
client2.my-domain.com
client3.my-domain.com

And EffectiveDatatable was not working properly. Searching raised an error. It tracked it down to the effective datatable's cookie not being sent.

This PR make it so that cookie will be shared for all subdomains.

Thoughts?