### PR TITLE
Add support for multiple locales and integrate with Rails I18n system

### DIFF
--- a/app/assets/javascripts/dataTables/locales/Chinese-traditional.lang
+++ b/app/assets/javascripts/dataTables/locales/Chinese-traditional.lang
@@ -1,0 +1,29 @@
+/**
+ * Chinese (traditional) translation
+ *  @name Chinese (traditional)
+ *  @anchor Chinese (traditional)
+ *  @author <a href="https://gimmerank.com/">GimmeRank Affiliate</a>
+ *  @author <a href="https://github.com/PeterDaveHello">Peter Dave Hello</a>
+ */
+
+{
+	"processing":   "處理中...",
+	"loadingRecords": "載入中...",
+	"lengthMenu":   "顯示 _MENU_ 項結果",
+	"zeroRecords":  "沒有符合的結果",
+	"info":         "顯示第 _START_ 至 _END_ 項結果，共 _TOTAL_ 項",
+	"infoEmpty":    "顯示第 0 至 0 項結果，共 0 項",
+	"infoFiltered": "(從 _MAX_ 項結果中過濾)",
+	"infoPostFix":  "",
+	"search":       "搜尋:",
+	"paginate": {
+		"first":    "第一頁",
+		"previous": "上一頁",
+		"next":     "下一頁",
+		"last":     "最後一頁"
+	},
+	"aria": {
+		"sortAscending":  ": 升冪排列",
+		"sortDescending": ": 降冪排列"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/Indonesian-Alternative.lang
+++ b/app/assets/javascripts/dataTables/locales/Indonesian-Alternative.lang
@@ -1,0 +1,24 @@
+/**
+ * Indonesian translation
+ *  @name Indonesian
+ *  @anchor Indonesian
+ *  @author Landung Wahana
+ */
+
+{
+   "sProcessing":   "Sedang proses...",
+   "sLengthMenu":   "Tampilan _MENU_ entri",
+   "sZeroRecords":  "Tidak ditemukan data yang sesuai",
+   "sInfo":         "Tampilan _START_ sampai _END_ dari _TOTAL_ entri",
+   "sInfoEmpty":    "Tampilan 0 hingga 0 dari 0 entri",
+   "sInfoFiltered": "(disaring dari _MAX_ entri keseluruhan)",
+   "sInfoPostFix":  "",
+   "sSearch":       "Cari:",
+   "sUrl":          "",
+   "oPaginate": {
+       "sFirst":    "Awal",
+       "sPrevious": "Balik",
+       "sNext":     "Lanjut",
+       "sLast":     "Akhir"
+   }
+}

--- a/app/assets/javascripts/dataTables/locales/Khmer.lang
+++ b/app/assets/javascripts/dataTables/locales/Khmer.lang
@@ -1,0 +1,30 @@
+/**
+ * Khmer translation
+ *  @name Khmer
+ *  @anchor Khmer
+ *  @author Sokunthearith Makara
+ */
+
+{
+    "sEmptyTable":     "មិនមានទិន្នន័យក្នុងតារាងនេះទេ",
+    "sInfo":           "បង្ហាញជួរទី _START_ ដល់ទី _END_ ក្នុងចំណោម _TOTAL_ ជួរ",
+    "sInfoEmpty":      "បង្ហាញជួរទី 0 ដល់ទី 0 ក្នុងចំណោម 0 ជួរ",
+    "sInfoFiltered":   "(បានចម្រាញ់ចេញពីទិន្នន័យសរុប _MAX_ ជួរ)",
+    "sInfoPostFix":    "",
+    "sInfoThousands":  ",",
+    "sLengthMenu":     "បង្ហាញ _MENU_ ជួរ",
+    "sLoadingRecords": "កំពុងផ្ទុក...",
+    "sProcessing":     "កំពុងដំណើរការ...",
+    "sSearch":         "ស្វែងរក:",
+    "sZeroRecords":    "មិនមានទិន្នន័យត្រូវតាមលក្ខខណ្ឌស្វែងរកទេ",
+    "oPaginate": {
+        "sFirst":    "ដំបូងគេ",
+        "sLast":     "ចុងក្រោយ",
+        "sNext":     "បន្ទាប់",
+        "sPrevious": "ក្រោយ"
+    },
+    "oAria": {
+        "sSortAscending":  ": ចុចដើម្បីរៀបជួរឈរនេះតាមលំដាប់ឡើង",
+        "sSortDescending": ": ចុចដើម្បីរៀបជួរឈរនេះតាមលំដាប់ចុះ"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/Norwegian-Bokmal.lang
+++ b/app/assets/javascripts/dataTables/locales/Norwegian-Bokmal.lang
@@ -1,0 +1,33 @@
+/**
+ * Norwegian Bokmål translation
+ *  @name Norwegian-Bokmal
+ *  @anchor Norwegian-Bokmal
+ *  @author Petter Ekrann
+ *  @author Vegard Johannessen
+ */
+
+{
+	"sEmptyTable": "Ingen data tilgjengelig i tabellen",
+	"sInfo": "Viser _START_ til _END_ av _TOTAL_ linjer",
+	"sInfoEmpty": "Viser 0 til 0 av 0 linjer",
+	"sInfoFiltered": "(filtrert fra _MAX_ totalt antall linjer)",
+	"sInfoPostFix": "",
+	"sInfoThousands": " ",
+	"sLoadingRecords": "Laster...",
+	"sLengthMenu": "Vis _MENU_ linjer",
+	"sLoadingRecords": "Laster...",
+	"sProcessing": "Laster...",
+	"sSearch": "S&oslash;k:",
+	"sUrl": "",
+	"sZeroRecords": "Ingen linjer matcher s&oslash;ket",
+  	"oPaginate": {
+		"sFirst": "F&oslash;rste",
+		"sPrevious": "Forrige",
+		"sNext": "Neste",
+		"sLast": "Siste"
+   	},
+   	"oAria": {
+		"sSortAscending": ": aktiver for å sortere kolonnen stigende",
+		"sSortDescending": ": aktiver for å sortere kolonnen synkende"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/Norwegian-Nynorsk.lang
+++ b/app/assets/javascripts/dataTables/locales/Norwegian-Nynorsk.lang
@@ -1,0 +1,33 @@
+/**
+ * Norwegian Nynorsk translation
+ *  @name Norwegian-Nynorsk
+ *  @anchor Norwegian-Nynorsk
+ *  @author Andreas-Johann Østerdal Ulvestad
+ */
+
+
+{
+    "sEmptyTable": "Inga data tilgjengeleg i tabellen",
+    "sInfo": "Syner _START_ til _END_ av _TOTAL_ linjer",
+    "sInfoEmpty": "Syner 0 til 0 av 0 linjer",
+    "sInfoFiltered": "(filtrert frå _MAX_ totalt antal linjer)",
+    "sInfoPostFix": "",
+    "sInfoThousands": " ",
+    "sLoadingRecords": "Lastar...",
+    "sLengthMenu": "Syn _MENU_ linjer",
+    "sLoadingRecords": "Lastar...",
+    "sProcessing": "Lastar...",
+    "sSearch": "S&oslash;k:",
+    "sUrl": "",
+    "sZeroRecords": "Inga linjer treff p&aring; s&oslash;ket",
+    "oPaginate": {
+        "sFirst": "Fyrste",
+        "sPrevious": "Forrige",
+        "sNext": "Neste",
+        "sLast": "Siste"
+    },
+    "oAria": {
+        "sSortAscending": ": aktiver for å sortere kolonna stigande",
+        "sSortDescending": ": aktiver for å sortere kolonna synkande"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/Portuguese-Brasil.lang
+++ b/app/assets/javascripts/dataTables/locales/Portuguese-Brasil.lang
@@ -1,0 +1,37 @@
+/**
+ * Portuguese Brasil translation
+ *  @name Portuguese Brasil
+ *  @anchor Portuguese Brasil
+ *  @author Julio Cesar Viana Palma
+ */
+
+{
+    "sEmptyTable": "Nenhum registro encontrado",
+    "sInfo": "Mostrando de _START_ até _END_ de _TOTAL_ registros",
+    "sInfoEmpty": "Mostrando 0 até 0 de 0 registros",
+    "sInfoFiltered": "(Filtrados de _MAX_ registros)",
+    "sInfoPostFix": "",
+    "sInfoThousands": ".",
+    "sLengthMenu": "_MENU_ resultados por página",
+    "sLoadingRecords": "Carregando...",
+    "sProcessing": "Processando...",
+    "sZeroRecords": "Nenhum registro encontrado",
+    "sSearch": "Pesquisar",
+    "oPaginate": {
+        "sNext": "Próximo",
+        "sPrevious": "Anterior",
+        "sFirst": "Primeiro",
+        "sLast": "Último"
+    },
+    "oAria": {
+        "sSortAscending": ": Ordenar colunas de forma ascendente",
+        "sSortDescending": ": Ordenar colunas de forma descendente"
+    },
+    "select": {
+        "rows": {
+            "_": "Selecionado %d linhas",
+            "0": "Nenhuma linha selecionada",
+            "1": "Selecionado 1 linha"
+        }
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/Serbian_latin.lang
+++ b/app/assets/javascripts/dataTables/locales/Serbian_latin.lang
@@ -1,0 +1,30 @@
+/**
+ * Serbian translation (Latin alphabet)
+ *  @name Serbian (Latin)
+ *  @anchor Serbian (Latin)
+ *  @author <a href="http://mnovakovic.byteout.com">Marko Novakovic</a>
+ */
+
+{
+	"sEmptyTable":     "Nema podataka u tabeli",
+	"sInfo":           "Prikaz _START_ do _END_ od ukupno _TOTAL_ zapisa",
+	"sInfoEmpty":      "Prikaz 0 do 0 od ukupno 0 zapisa",
+	"sInfoFiltered":   "(filtrirano od ukupno _MAX_ zapisa)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Prikaži _MENU_ zapisa",
+	"sLoadingRecords": "Učitavanje...",
+	"sProcessing":     "Obrada...",
+	"sSearch":         "Pretraga:",
+	"sZeroRecords":    "Nisu pronađeni odgovarajući zapisi",
+	"oPaginate": {
+		"sFirst":    "Početna",
+		"sLast":     "Poslednja",
+		"sNext":     "Sledeća",
+		"sPrevious": "Predhodna"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivirajte da sortirate kolonu uzlazno",
+		"sSortDescending": ": aktivirajte da sortirate kolonu silazno"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/af
+++ b/app/assets/javascripts/dataTables/locales/af
@@ -1,0 +1,30 @@
+/**
+ * Afrikaans translation
+ *  @name Afrikaans
+ *  @anchor Afrikaans
+ *  @author <a href="http://www.ajoft.com">Ajoft Software</a>
+ */
+
+{
+	"sEmptyTable":     "Geen data beskikbaar in tabel",
+	"sInfo":           "uitstalling _START_ to _END_ of _TOTAL_ inskrywings",
+	"sInfoEmpty":      "uitstalling 0 to 0 of 0 inskrywings",
+	"sInfoFiltered":   "(gefiltreer uit _MAX_ totaal inskrywings)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "uitstal _MENU_ inskrywings",
+	"sLoadingRecords": "laai...",
+	"sProcessing":     "verwerking...",
+	"sSearch":         "soektog:",
+	"sZeroRecords":    "Geen treffers gevind",
+	"oPaginate": {
+		"sFirst":    "eerste",
+		"sLast":     "laaste",
+		"sNext":     "volgende",
+		"sPrevious": "vorige"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktiveer kolom stygende te sorteer",
+		"sSortDescending": ": aktiveer kolom orde te sorteer"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/am
+++ b/app/assets/javascripts/dataTables/locales/am
@@ -1,0 +1,30 @@
+/**
+ * Amharic translation
+ *  @name Amharic
+ *  @anchor Amharic
+ *  @author veduket
+ */
+
+{
+    "sEmptyTable":     "ባዶ ሰንጠረዥ",
+    "sInfo":           "ከጠቅላላው _TOTAL_ ዝርዝሮች ውስጥ ከ _START_ እስከ _END_ ያሉት ዝርዝር",
+    "sInfoEmpty":      "ከጠቅላላው 0 ዝርዝሮች ውስጥ ከ 0 እስከ 0 ያሉት ዝርዝር",
+    "sInfoFiltered":   "(ከጠቅላላው _MAX_ የተመረጡ ዝርዝሮች)",
+    "sInfoPostFix":    "",
+    "sInfoThousands":  ",",
+    "sLengthMenu":     "የዝርዝሮች ብዛት _MENU_",
+    "sLoadingRecords": "በማቅረብ ላይ...",
+    "sProcessing":     "በማቀናበር ላይ...",
+    "sSearch":         "ፈልግ:",
+    "sZeroRecords":    "ከሚፈለገው ጋር የሚሚሳሰል ዝርዝር አልተገኘም",
+    "oPaginate": {
+        "sFirst":    "መጀመሪያ",
+        "sLast":     "መጨረሻ",
+        "sNext":     "ቀጣዩ",
+        "sPrevious": "የበፊቱ"
+    },
+    "oAria": {
+        "sSortAscending":  ": ከመጀመሪያ ወደ መጨረሻ(ወጪ) አደራደር",
+        "sSortDescending": ": ከመጨረሻ ወደ መጀመሪያ(ወራጅ) አደራደር"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/ar
+++ b/app/assets/javascripts/dataTables/locales/ar
@@ -1,0 +1,30 @@
+/**
+ * Arabic translation
+ *  @name Arabic
+ *  @anchor Arabic
+ *  @author Ossama Khayat
+ */
+
+{
+	"sEmptyTable":     "ليست هناك بيانات متاحة في الجدول",
+	"sLoadingRecords": "جارٍ التحميل...",
+	"sProcessing":   "جارٍ التحميل...",
+	"sLengthMenu":   "أظهر _MENU_ مدخلات",
+	"sZeroRecords":  "لم يعثر على أية سجلات",
+	"sInfo":         "إظهار _START_ إلى _END_ من أصل _TOTAL_ مدخل",
+	"sInfoEmpty":    "يعرض 0 إلى 0 من أصل 0 سجل",
+	"sInfoFiltered": "(منتقاة من مجموع _MAX_ مُدخل)",
+	"sInfoPostFix":  "",
+	"sSearch":       "ابحث:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "الأول",
+		"sPrevious": "السابق",
+		"sNext":     "التالي",
+		"sLast":     "الأخير"
+	},
+	"oAria": {
+		"sSortAscending":  ": تفعيل لترتيب العمود تصاعدياً",
+		"sSortDescending": ": تفعيل لترتيب العمود تنازلياً"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/az
+++ b/app/assets/javascripts/dataTables/locales/az
@@ -1,0 +1,30 @@
+/**
+ * Azerbaijan translation
+ *  @name Azerbaijan
+ *  @anchor Azerbaijan
+ *  @author H.Huseyn
+ */
+
+{
+	"sEmptyTable":     "Cədvəldə heç bir məlumat yoxdur",
+	"sInfo":           " _TOTAL_ Nəticədən _START_ - _END_ Arası Nəticələr",
+	"sInfoEmpty":      "Nəticə Yoxdur",
+	"sInfoFiltered":   "( _MAX_ Nəticə İçindən Tapılanlar)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "Səhifədə _MENU_ Nəticə Göstər",
+	"sLoadingRecords": "Yüklənir...",
+	"sProcessing":     "Gözləyin...",
+	"sSearch":         "Axtarış:",
+	"sZeroRecords":    "Nəticə Tapılmadı.",
+	"oPaginate": {
+		"sFirst":    "İlk",
+		"sLast":     "Axırıncı",
+		"sNext":     "Sonraki",
+		"sPrevious": "Öncəki"
+	},
+	"oAria": {
+		"sSortAscending":  ": sütunu artma sırası üzərə aktiv etmək",
+		"sSortDescending": ": sütunu azalma sırası üzərə aktiv etmək"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/be
+++ b/app/assets/javascripts/dataTables/locales/be
@@ -1,0 +1,27 @@
+/**
+* Belarusian translation
+* @name Belarusian
+* @anchor Belarusian
+* @author vkachurka
+*/
+{
+	"sProcessing":   "Пачакайце...",
+	"sLengthMenu":   "Паказваць _MENU_ запісаў",
+	"sZeroRecords":  "Запісы адсутнічаюць.",
+	"sInfo":         "Запісы з _START_ па _END_ з _TOTAL_ запісаў",
+	"sInfoEmpty":    "Запісы з 0 па 0 з 0 запісаў",
+	"sInfoFiltered": "(адфільтравана з _MAX_ запісаў)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Пошук:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst": "Першая",
+		"sPrevious": "Папярэдняя",
+		"sNext": "Наступная",
+		"sLast": "Апошняя"
+	},
+	"oAria": {
+		"sSortAscending":  ": актываваць для сартавання слупка па ўзрастанні",
+		"sSortDescending": ": актываваць для сартавання слупка па змяншэнні"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/bg
+++ b/app/assets/javascripts/dataTables/locales/bg
@@ -1,0 +1,24 @@
+/**
+ * Bulgarian translation
+ *  @name Bulgarian
+ *  @anchor Bulgarian
+ *  @author Rostislav Stoyanov, Oliwier Thomas
+ */
+
+{
+	"sProcessing":   "Обработка на резултатите...",
+	"sLengthMenu":   "Показване на _MENU_ резултата",
+	"sZeroRecords":  "Няма намерени резултати",
+	"sInfo":         "Показване на резултати от _START_ до _END_ от общо _TOTAL_",
+	"sInfoEmpty":    "Показване на резултати от 0 до 0 от общо 0",
+	"sInfoFiltered": "(филтрирани от общо _MAX_ резултата)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Търсене:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Първа",
+		"sPrevious": "Предишна",
+		"sNext":     "Следваща",
+		"sLast":     "Последна"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/bn
+++ b/app/assets/javascripts/dataTables/locales/bn
@@ -1,0 +1,24 @@
+/**
+ * Bangla translation
+ *  @name Bangla
+ *  @anchor Bangla
+ *  @author <a href="http://khaledcse06.wordpress.com">Md. Khaled Ben Islam</a>
+ */
+
+{
+	"sProcessing":   "প্রসেসিং হচ্ছে...",
+	"sLengthMenu":   "_MENU_ টা এন্ট্রি দেখাও",
+	"sZeroRecords":  "আপনি যা অনুসন্ধান করেছেন তার সাথে মিলে যাওয়া কোন রেকর্ড খুঁজে পাওয়া যায় নাই",
+	"sInfo":         "_TOTAL_ টা এন্ট্রির মধ্যে _START_ থেকে _END_ পর্যন্ত দেখানো হচ্ছে",
+	"sInfoEmpty":    "কোন এন্ট্রি খুঁজে পাওয়া যায় নাই",
+	"sInfoFiltered": "(মোট _MAX_ টা এন্ট্রির মধ্যে থেকে বাছাইকৃত)",
+	"sInfoPostFix":  "",
+	"sSearch":       "অনুসন্ধান:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "প্রথমটা",
+		"sPrevious": "আগেরটা",
+		"sNext":     "পরবর্তীটা",
+		"sLast":     "শেষেরটা"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ca
+++ b/app/assets/javascripts/dataTables/locales/ca
@@ -1,0 +1,24 @@
+/**
+ * Catalan translation
+ *  @name Catalan
+ *  @anchor Catalan
+ *  @author Sergi
+ */
+
+{
+	"sProcessing":   "Processant...",
+	"sLengthMenu":   "Mostra _MENU_ registres",
+	"sZeroRecords":  "No s'han trobat registres.",
+	"sInfo":         "Mostrant de _START_ a _END_ de _TOTAL_ registres",
+	"sInfoEmpty":    "Mostrant de 0 a 0 de 0 registres",
+	"sInfoFiltered": "(filtrat de _MAX_ total registres)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Filtrar:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Primer",
+		"sPrevious": "Anterior",
+		"sNext":     "Següent",
+		"sLast":     "Últim"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/cr
+++ b/app/assets/javascripts/dataTables/locales/cr
@@ -1,0 +1,35 @@
+/**
+ * Greek translation
+ *  @name Greek
+ *  @anchor Greek
+ *  @author Abraam Ziogas
+ *  @author Leonidas Arvanitis
+ */
+
+{
+	"sDecimal":           ",",
+	"sEmptyTable":        "Δεν υπάρχουν δεδομένα στον πίνακα",
+	"sInfo":              "Εμφανίζονται _START_ έως _END_ από _TOTAL_ εγγραφές",
+	"sInfoEmpty":         "Εμφανίζονται 0 έως 0 από 0 εγγραφές",
+	"sInfoFiltered":      "(φιλτραρισμένες από _MAX_ συνολικά εγγραφές)",
+	"sInfoPostFix":       "",
+	"sInfoThousands":     ".",
+	"sLengthMenu":        "Δείξε _MENU_ εγγραφές",
+	"sLoadingRecords":    "Φόρτωση...",
+	"sProcessing":        "Επεξεργασία...",
+	"sSearch":            "Αναζήτηση:",
+	"sSearchPlaceholder": "Αναζήτηση",
+	"sThousands":         ".",
+	"sUrl":               "",
+	"sZeroRecords":       "Δεν βρέθηκαν εγγραφές που να ταιριάζουν",
+	"oPaginate": {
+		"sFirst":    "Πρώτη",
+		"sPrevious": "Προηγούμενη",
+		"sNext":     "Επόμενη",
+		"sLast":     "Τελευταία"
+	},
+	"oAria": {
+		"sSortAscending":  ": ενεργοποιήστε για αύξουσα ταξινόμηση της στήλης",
+		"sSortDescending": ": ενεργοποιήστε για φθίνουσα ταξινόμηση της στήλης"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/cs
+++ b/app/assets/javascripts/dataTables/locales/cs
@@ -1,0 +1,30 @@
+/**
+ * Czech translation
+ *  @name Czech
+ *  @anchor Czech
+ *  @author <a href="http://blog.magerio.cz/">Magerio</a>
+ */
+
+{
+	"sEmptyTable":     "Tabulka neobsahuje žádná data",
+	"sInfo":           "Zobrazuji _START_ až _END_ z celkem _TOTAL_ záznamů",
+	"sInfoEmpty":      "Zobrazuji 0 až 0 z 0 záznamů",
+	"sInfoFiltered":   "(filtrováno z celkem _MAX_ záznamů)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  " ",
+	"sLengthMenu":     "Zobraz záznamů _MENU_",
+	"sLoadingRecords": "Načítám...",
+	"sProcessing":     "Provádím...",
+	"sSearch":         "Hledat:",
+	"sZeroRecords":    "Žádné záznamy nebyly nalezeny",
+	"oPaginate": {
+		"sFirst":    "První",
+		"sLast":     "Poslední",
+		"sNext":     "Další",
+		"sPrevious": "Předchozí"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivujte pro řazení sloupce vzestupně",
+		"sSortDescending": ": aktivujte pro řazení sloupce sestupně"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/cy
+++ b/app/assets/javascripts/dataTables/locales/cy
@@ -1,0 +1,30 @@
+/**
+ * Welsh translation
+ *  @name Welsh
+ *  @anchor Welsh
+ *  @author <a href="https://eveoh.nl/">Marco Krikke</a>
+ */
+
+{
+	"sEmptyTable":     "Dim data ar gael yn y tabl",
+	"sInfo":           "Dangos _START_ i _END_ o _TOTAL_ cofnod",
+	"sInfoEmpty":      "Dangos 0 i 0 o 0 cofnod",
+	"sInfoFiltered":   "(wedi hidlo o gyfanswm o _MAX_ cofnod)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "Dangos _MENU_ cofnod",
+	"sLoadingRecords": "Wrthi'n llwytho...",
+	"sProcessing":     "Wrthi'n prosesu...",
+	"sSearch":         "Chwilio:",
+	"sZeroRecords":    "Heb ddod o hyd i gofnodion sy'n cyfateb",
+	"oPaginate": {
+		"sFirst":    "Cyntaf",
+		"sLast":     "Olaf",
+		"sNext":     "Nesaf",
+		"sPrevious": "Blaenorol"
+	},
+	"oAria": {
+		"sSortAscending":  ": rhoi ar waith i drefnu colofnau o'r lleiaf i'r mwyaf",
+		"sSortDescending": ": rhoi ar waith i drefnu colofnau o'r mwyaf i'r lleiaf"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/da
+++ b/app/assets/javascripts/dataTables/locales/da
@@ -1,0 +1,24 @@
+/**
+ * Danish translation
+ *  @name Danish
+ *  @anchor Danish
+ *  @author <a href="http://www.kor.dk/">Werner Knudsen</a>
+ */
+
+{
+	"sProcessing":   "Henter...",
+	"sLengthMenu":   "Vis _MENU_ linjer",
+	"sZeroRecords":  "Ingen linjer matcher s&oslash;gningen",
+	"sInfo":         "Viser _START_ til _END_ af _TOTAL_ linjer",
+	"sInfoEmpty":    "Viser 0 til 0 af 0 linjer",
+	"sInfoFiltered": "(filtreret fra _MAX_ linjer)",
+	"sInfoPostFix":  "",
+	"sSearch":       "S&oslash;g:",
+	"sUrl":          "",
+	"oPaginate": {
+	    "sFirst":    "F&oslash;rste",
+	    "sPrevious": "Forrige",
+	    "sNext":     "N&aelig;ste",
+	    "sLast":     "Sidste"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/de
+++ b/app/assets/javascripts/dataTables/locales/de
@@ -1,0 +1,54 @@
+/**
+ * German translation
+ *  @name German
+ *  @anchor German
+ *  @author Joerg Holz
+ *  @author DJmRek - Markus Bergt
+ *  @author OSWorX https://osworx.net
+ */
+
+{
+	"sEmptyTable":   	"Keine Daten in der Tabelle vorhanden",
+	"sInfo":         	"_START_ bis _END_ von _TOTAL_ Einträgen",
+	"sInfoEmpty":    	"Keine Daten vorhanden",
+	"sInfoFiltered": 	"(gefiltert von _MAX_ Einträgen)",
+	"sInfoPostFix":  	"",
+	"sInfoThousands":  	".",
+	"sLengthMenu":   	"_MENU_ Einträge anzeigen",
+	"sLoadingRecords": 	"Wird geladen ..",
+	"sProcessing":   	"Bitte warten ..",
+	"sSearch":       	"Suchen",
+	"sZeroRecords":  	"Keine Einträge vorhanden",
+	"oPaginate": {
+		"sFirst":    	"Erste",
+		"sPrevious": 	"Zurück",
+		"sNext":     	"Nächste",
+		"sLast":     	"Letzte"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivieren, um Spalte aufsteigend zu sortieren",
+		"sSortDescending": ": aktivieren, um Spalte absteigend zu sortieren"
+	},
+	"select": {
+    	"rows": {
+			"_": "%d Zeilen ausgewählt",
+			"0": "",
+			"1": "1 Zeile ausgewählt"
+	    }
+	},
+	"buttons": {
+		"print":	"Drucken",
+		"colvis":	"Spalten",
+		"copy":		"Kopieren",
+		"copyTitle":	"In Zwischenablage kopieren",
+		"copyKeys":	"Taste <i>ctrl</i> oder <i>\u2318</i> + <i>C</i> um Tabelle<br>in Zwischenspeicher zu kopieren.<br><br>Um abzubrechen die Nachricht anklicken oder Escape drücken.",
+		"copySuccess": {
+			"_": "%d Zeilen kopiert",
+			"1": "1 Zeile kopiert"
+		},
+		"pageLength": {
+			"-1": "Zeige alle Zeilen",
+			"_":  "Zeige %d Zeilen"
+		}
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/en
+++ b/app/assets/javascripts/dataTables/locales/en
@@ -1,0 +1,33 @@
+/**
+ * English - this is the default DataTables ships with
+ *  @name English
+ *  @anchor English
+ *  @author <a href="http://www.sprymedia.co.uk/">Allan Jardine</a>
+ */
+
+{
+	"sEmptyTable":     "No data available in table",
+	"sInfo":           "Showing _START_ to _END_ of _TOTAL_ entries",
+	"sInfoEmpty":      "Showing 0 to 0 of 0 entries",
+	"sInfoFiltered":   "(filtered from _MAX_ total entries)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "&nbsp;with _MENU_ per page",
+	"sLoadingRecords": "Loading...",
+	"sProcessing":     "Processing...",
+	"sSearch":         "Search:",
+	"sZeroRecords":    "No matching records found",
+	"oPaginate": {
+		"sFirst":    "First",
+		"sLast":     "Last",
+		"sNext":     "Next",
+		"sPrevious": "Previous"
+	},
+	"oAria": {
+		"sSortAscending":  ": activate to sort column ascending",
+		"sSortDescending": ": activate to sort column descending"
+	},
+  "buttons": {
+    "colvis": "Show / Hide"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/eo
+++ b/app/assets/javascripts/dataTables/locales/eo
@@ -1,0 +1,30 @@
+/**
+ * Esperanto
+ *  @name Esperanto
+ *  @anchor Esperanto
+ *  @author <a href="https://miestasmia.com">Mia Nordentoft</a>
+ */
+
+{
+	"sEmptyTable":     "Neniuj datumoj en tabelo",
+	"sInfo":           "Montras _START_ ĝis _END_ el _TOTAL_ vicoj",
+	"sInfoEmpty":      "Montras 0 ĝis 0 el 0 vicoj",
+	"sInfoFiltered":   "(filtrita el entute _MAX_ vicoj)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Montri _MENU_ vicojn",
+	"sLoadingRecords": "Ŝarĝas ...",
+	"sProcessing":     "Pretigas ...",
+	"sSearch":         "Serĉi:",
+	"sZeroRecords":    "Neniuj rezultoj trovitaj",
+	"oPaginate": {
+		"sFirst":    "Unua",
+		"sLast":     "Lasta",
+		"sNext":     "Venonta",
+		"sPrevious": "Antaŭa"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivigi por filtri kolumnon kreskante",
+		"sSortDescending": ": aktivigi por filtri kolumnon malkreskante"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/es
+++ b/app/assets/javascripts/dataTables/locales/es
@@ -1,0 +1,36 @@
+/**
+ * Spanish translation
+ *  @name Spanish
+ *  @anchor Spanish
+ *  @author Giovanni Ariza, Aristobulo Gomez and Roberto Poo
+ */
+
+{
+	"sProcessing":     "Procesando...",
+  "sLengthMenu":     "Mostrar _MENU_ registros",
+  "sZeroRecords":    "No se encontraron resultados",
+  "sEmptyTable":     "Ningún dato disponible en esta tabla =(",
+  "sInfo":           "Mostrando registros del _START_ al _END_ de un total de _TOTAL_ registros",
+  "sInfoEmpty":      "Mostrando registros del 0 al 0 de un total de 0 registros",
+  "sInfoFiltered":   "(filtrado de un total de _MAX_ registros)",
+  "sLengthMenu":     "&nbsp; con _MENU_ por página",
+  "sInfoPostFix":    "",
+  "sSearch":         "Buscar:",
+  "sUrl":            "",
+  "sInfoThousands":  ",",
+  "sLoadingRecords": "Cargando...",
+  "oPaginate": {
+      "sFirst":    "Primero",
+      "sLast":     "Último",
+      "sNext":     "Siguiente",
+      "sPrevious": "Anterior"
+  },
+  "oAria": {
+      "sSortAscending":  ": Activar para ordenar la columna de manera ascendente",
+      "sSortDescending": ": Activar para ordenar la columna de manera descendente"
+  },
+  "buttons": {
+      "copy": "Copiar",
+      "colvis": "Mostrar/Ocultar"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/et
+++ b/app/assets/javascripts/dataTables/locales/et
@@ -1,0 +1,23 @@
+/**
+ * Estonian translation
+ *  @name Estonian
+ *  @anchor Estonian
+ *  @author <a href="http://www.arts9.com/">Janek Todoruk</a>
+ */
+
+{
+	"sProcessing":   "Palun oodake, koostan kuvamiseks nimekirja!",
+	"sLengthMenu":   "N&auml;ita kirjeid _MENU_ kaupa",
+	"sZeroRecords":  "Otsitavat vastet ei leitud.",
+	"sInfo":         "Kuvatud: _TOTAL_ kirjet (_START_-_END_)",
+	"sInfoEmpty":    "Otsinguvasteid ei leitud",
+	"sInfoFiltered": " - filteeritud _MAX_ kirje seast.",
+	"sInfoPostFix":  "K&otilde;ik kuvatud kirjed p&otilde;hinevad reaalsetel tulemustel.",
+	"sSearch":       "Otsi k&otilde;ikide tulemuste seast:",
+	"oPaginate": {
+		"sFirst":      "Algus",
+		"sPrevious":   "Eelmine",
+		"sNext":       "J&auml;rgmine",
+		"sLast":       "Viimane"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/eu
+++ b/app/assets/javascripts/dataTables/locales/eu
@@ -1,0 +1,31 @@
+/**
+ * Basque translation
+ *  @name Basque
+ *  @anchor Basque
+ *  @author <a href="https://github.com/xabikip/">Xabi Pico</a>
+ */
+
+{
+	"sProcessing":     "Prozesatzen...",
+	"sLengthMenu":     "Erakutsi _MENU_ erregistro",
+	"sZeroRecords":    "Ez da emaitzarik aurkitu",
+	"sEmptyTable":     "Taula hontan ez dago inongo datu erabilgarririk",
+	"sInfo":           "_START_ -etik _END_ -erako erregistroak erakusten, guztira _TOTAL_ erregistro",
+	"sInfoEmpty":      "0tik 0rako erregistroak erakusten, guztira 0 erregistro",
+	"sInfoFiltered":   "(guztira _MAX_ erregistro iragazten)",
+	"sInfoPostFix":    "",
+	"sSearch":         "Aurkitu:",
+	"sUrl":            "",
+	"sInfoThousands":  ",",
+	"sLoadingRecords": "Abiarazten...",
+	"oPaginate": {
+		"sFirst":    "Lehena",
+		"sLast":     "Azkena",
+		"sNext":     "Hurrengoa",
+		"sPrevious": "Aurrekoa"
+	},
+	"oAria": {
+		"sSortAscending":  ": Zutabea goranzko eran ordenatzeko aktibatu ",
+		"sSortDescending": ": Zutabea beheranzko eran ordenatzeko aktibatu"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/fa
+++ b/app/assets/javascripts/dataTables/locales/fa
@@ -1,0 +1,31 @@
+/**
+ * Persian translation
+ *  @name Persian
+ *  @anchor Persian
+ *  @author <a href="http://www.chavoshi.com/">Ehsan Chavoshi</a>
+ *  @author <a href="http://www.robowiki.ir/">Mohammad Babazadeh</a>
+ */
+
+{
+	"sEmptyTable":     "هیچ داده‌ای در جدول وجود ندارد",
+	"sInfo":           "نمایش _START_ تا _END_ از _TOTAL_ ردیف",
+	"sInfoEmpty":      "نمایش 0 تا 0 از 0 ردیف",
+	"sInfoFiltered":   "(فیلتر شده از _MAX_ ردیف)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "نمایش _MENU_ ردیف",
+	"sLoadingRecords": "در حال بارگزاری...",
+	"sProcessing":     "در حال پردازش...",
+	"sSearch":         "جستجو:",
+	"sZeroRecords":    "رکوردی با این مشخصات پیدا نشد",
+	"oPaginate": {
+		"sFirst":    "برگه‌ی نخست",
+		"sLast":     "برگه‌ی آخر",
+		"sNext":     "بعدی",
+		"sPrevious": "قبلی"
+	},
+	"oAria": {
+		"sSortAscending":  ": فعال سازی نمایش به صورت صعودی",
+		"sSortDescending": ": فعال سازی نمایش به صورت نزولی"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/fi
+++ b/app/assets/javascripts/dataTables/locales/fi
@@ -1,0 +1,48 @@
+/**
+ * Finnish translation
+ *  @name Finnish
+ *  @anchor Finnish
+ *  @author Seppo Äyräväinen
+ *  @author Viktors Cvetkovs
+ *  @author <a href="https://ironlions.fi">Niko Granö</a>
+ */
+
+{
+	"sEmptyTable":   "Ei näytettäviä tuloksia.",
+	"sInfo":         "Näytetään rivit _START_ - _END_ (yhteensä _TOTAL_ )",
+	"sInfoEmpty":    "Näytetään 0 - 0 (yhteensä 0)",
+	"sInfoFiltered": "(suodatettu _MAX_ tuloksen joukosta)",
+	"sInfoPostFix":  "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":   "Näytä kerralla _MENU_ riviä",
+	"sLoadingRecords": "Ladataan...", 
+	"sProcessing":   "Hetkinen...",
+	"sSearch":       "Etsi:",
+	"sZeroRecords":  "Tietoja ei löytynyt",
+	"oPaginate": {
+		"sFirst":    "Ensimmäinen",
+		"sLast":     "Viimeinen",
+		"sNext":     "Seuraava",
+		"sPrevious": "Edellinen"
+	},
+	"oAria": {
+		"sSortAscending":  ": lajittele sarake nousevasti",
+		"sSortDescending": ": lajittele sarake laskevasti"
+	},
+	"select": {
+		"rows": {
+			"_": "Valittuna %d riviä",
+			"0": "Klikkaa riviä valitaksesi sen",
+			"1": "Valittuna vain yksi rivi"
+		}
+	},
+	"buttons": {
+		"copy": "Kopioi",
+		"copySuccess": {
+			"1": "Yksi rivi kopioitu leikepöydälle",
+			"_": "%d riviä kopioitu leikepöydälle"
+		},
+		"copyTitle": "Kopioi leikepöydälle",
+		"copyKeys": "Paina <i>ctrl</i> tai <i>\u2318</i> + <i>C</i> kopioidaksesi taulukon arvot<br> leikepöydälle. <br><br>Peruuttaaksesi klikkaa tähän tai Esc."
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/fr
+++ b/app/assets/javascripts/dataTables/locales/fr
@@ -1,0 +1,37 @@
+/**
+ * French translation
+ *  @name French
+ *  @anchor French
+ *  @author schizophrene
+ */
+
+{
+	"sEmptyTable":     "Aucune donnée disponible dans le tableau",
+	"sInfo":           "Affichage de l'élément _START_ à _END_ sur _TOTAL_ éléments",
+	"sInfoEmpty":      "Affichage de l'élément 0 à 0 sur 0 élément",
+	"sInfoFiltered":   "(filtré à partir de _MAX_ éléments au total)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "Afficher _MENU_ éléments",
+	"sLoadingRecords": "Chargement...",
+	"sProcessing":     "Traitement...",
+	"sSearch":         "Rechercher :",
+	"sZeroRecords":    "Aucun élément correspondant trouvé",
+	"oPaginate": {
+		"sFirst":    "Premier",
+		"sLast":     "Dernier",
+		"sNext":     "Suivant",
+		"sPrevious": "Précédent"
+	},
+	"oAria": {
+		"sSortAscending":  ": activer pour trier la colonne par ordre croissant",
+		"sSortDescending": ": activer pour trier la colonne par ordre décroissant"
+	},
+	"select": {
+        	"rows": {
+         		"_": "%d lignes sélectionnées",
+         		"0": "Aucune ligne sélectionnée",
+        		"1": "1 ligne sélectionnée"
+        	}  
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ga
+++ b/app/assets/javascripts/dataTables/locales/ga
@@ -1,0 +1,24 @@
+/**
+ * Irish translation
+ *  @name Irish
+ *  @anchor Irish
+ *  @author <a href="http://letsbefamous.com">Lets Be Famous Journal</a>
+ */
+
+{
+	"sProcessing":   "Próiseáil...",
+	"sLengthMenu":   "Taispeáin iontrálacha _MENU_",
+	"sZeroRecords":  "Gan aon taifead meaitseáil aimsithe",
+	"sInfo":         "_START_ Showing a _END_ na n-iontrálacha  _TOTAL_",
+	"sInfoEmpty":    "Showing 0-0 na n-iontrálacha  0",
+	"sInfoFiltered": "(scagtha ó _MAX_ iontrálacha iomlán)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Cuardaigh:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "An Chéad",
+		"sPrevious": "Roimhe Seo",
+		"sNext":     "Ar Aghaidh",
+		"sLast":     "Last"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/gl
+++ b/app/assets/javascripts/dataTables/locales/gl
@@ -1,0 +1,32 @@
+/**
+ * Galician translation
+ *  @name Galician
+ *  @anchor Galician
+ *  @author <i>Emilio</i>
+ *  @author <i>Xosé Antonio Rubal López</i>
+ */
+
+{
+	"sProcessing":     "Procesando...",
+	"sLengthMenu":     "Mostrar _MENU_ rexistros",
+	"sZeroRecords":    "Non se atoparon resultados",
+	"sEmptyTable":     "Ningún dato dispoñible nesta táboa",
+	"sInfo":           "Mostrando rexistros do _START_ ao _END_ dun total de _TOTAL_ rexistros",
+	"sInfoEmpty":      "Mostrando rexistros do 0 ao 0 dun total de 0 rexistros",
+	"sInfoFiltered":   "(filtrado dun total de _MAX_ rexistros)",
+	"sInfoPostFix":    "",
+	"sSearch":         "Buscar:",
+	"sUrl":            "",
+	"sInfoThousands":  ",",
+	"sLoadingRecords": "Cargando...",
+	"oPaginate": {
+		"sFirst":    "Primeiro",
+		"sLast":     "Último",
+		"sNext":     "Seguinte",
+		"sPrevious": "Anterior"
+	},
+	"oAria": {
+		"sSortAscending":  ": Activar para ordenar a columna de maneira ascendente",
+		"sSortDescending": ": Activar para ordenar a columna de maneira descendente"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/gu
+++ b/app/assets/javascripts/dataTables/locales/gu
@@ -1,0 +1,30 @@
+/**
+ * Gujarati translation
+ *  @name Gujarati
+ *  @anchor Gujarati
+ *  @author <a href="http://www.apoto.com/">Apoto</a>
+ */
+
+{
+	"sEmptyTable":     "કોષ્ટકમાં કોઈ ડેટા ઉપલબ્ધ નથી",
+	"sInfo":           "કુલ_પ્રવેશો_અંત_પ્રારંભ_દર્શાવે_છે",
+	"sInfoEmpty":      "0 પ્રવેશો 0 0 બતાવી રહ્યું છે",
+	"sInfoFiltered":   "(_MAX_ કુલ પ્રવેશો માંથી ફિલ્ટર)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "બતાવો _MENU_ પ્રવેશો",
+	"sLoadingRecords": "લોડ કરી રહ્યું છે ...",
+	"sProcessing":     "પ્રક્રિયા ...",
+	"sSearch":         "શોધો:",
+	"sZeroRecords":    "કોઈ મેળ ખાતા રેકોર્ડ મળી",
+	"oPaginate": {
+		"sFirst":      "પ્રથમ",
+		"sLast":       "અંતિમ",
+		"sNext":       "આગામી",
+		"sPrevious":   "ગત"
+	},
+	"oAria": {
+		"sSortAscending":  ": સ્તંભ ચડતા ક્રમમાં ગોઠવવા માટે સક્રિય",
+		"sSortDescending": ": કૉલમ ઉતરતા ક્રમમાં ગોઠવવા માટે સક્રિય"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/he
+++ b/app/assets/javascripts/dataTables/locales/he
@@ -1,0 +1,25 @@
+/**
+ * Hebrew translation
+ *  @name Hebrew
+ *  @anchor Hebrew
+ *  @author <a href="http://ww3.co.il/">Neil Osman (WW3)</a>
+ */
+
+{
+    "processing":   "מעבד...",
+    "lengthMenu":   "הצג _MENU_ פריטים",
+    "zeroRecords":  "לא נמצאו רשומות מתאימות",
+    "emptyTable":   "לא נמצאו רשומות מתאימות",
+    "info": "_START_ עד _END_ מתוך _TOTAL_ רשומות" ,
+    "infoEmpty":    "0 עד 0 מתוך 0 רשומות",
+    "infoFiltered": "(מסונן מסך _MAX_  רשומות)",
+    "infoPostFix":  "",
+    "search":       "חפש:",
+    "url":          "",
+    "paginate": {
+        "first":    "ראשון",
+        "previous": "קודם",
+        "next":     "הבא",
+        "last":     "אחרון"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/hi
+++ b/app/assets/javascripts/dataTables/locales/hi
@@ -1,0 +1,24 @@
+/**
+ * Hindi translation
+ *  @name Hindi
+ *  @anchor Hindi
+ *  @author <a href="http://outshinesolutions.com">Outshine Solutions</a>
+ */
+
+{
+	"sProcessing":   "प्रगति पे हैं ...",
+	"sLengthMenu":   " _MENU_ प्रविष्टियां दिखाएं ",
+	"sZeroRecords":  "रिकॉर्ड्स का मेल नहीं मिला",
+	"sInfo":         "_START_ to _END_ of _TOTAL_ प्रविष्टियां दिखा रहे हैं",
+	"sInfoEmpty":    "0 में से 0 से 0 प्रविष्टियां दिखा रहे हैं",
+	"sInfoFiltered": "(_MAX_ कुल प्रविष्टियों में से छठा हुआ)",
+	"sInfoPostFix":  "",
+	"sSearch":       "खोजें:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "प्रथम",
+		"sPrevious": "पिछला",
+		"sNext":     "अगला",
+		"sLast":     "अंतिम"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/hr
+++ b/app/assets/javascripts/dataTables/locales/hr
@@ -1,0 +1,30 @@
+/**
+ * Croatian translation
+ *  @name Croatian
+ *  @anchor Croatian
+ *  @author Predrag Mušić and _hrvoj3e_
+ */
+
+{
+    "sEmptyTable":      "Nema podataka u tablici",
+    "sInfo":            "Prikazano _START_ do _END_ od _TOTAL_ rezultata",
+    "sInfoEmpty":       "Prikazano 0 do 0 od 0 rezultata",
+    "sInfoFiltered":    "(filtrirano iz _MAX_ ukupnih rezultata)",
+    "sInfoPostFix":     "",
+    "sInfoThousands":   ",",
+    "sLengthMenu":      "Prikaži _MENU_ rezultata po stranici",
+    "sLoadingRecords":  "Dohvaćam...",
+    "sProcessing":      "Obrađujem...",
+    "sSearch":          "Pretraži:",
+    "sZeroRecords":     "Ništa nije pronađeno",
+    "oPaginate": {
+        "sFirst":       "Prva",
+        "sPrevious":    "Nazad",
+        "sNext":        "Naprijed",
+        "sLast":        "Zadnja"
+    },
+    "oAria": {
+        "sSortAscending":  ": aktiviraj za rastući poredak",
+        "sSortDescending": ": aktiviraj za padajući poredak"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/hu
+++ b/app/assets/javascripts/dataTables/locales/hu
@@ -1,0 +1,47 @@
+/**
+ * Hungarian translation
+ *  @name Hungarian
+ *  @anchor Hungarian
+ *  @author <a href="http://www.maschek.hu">Adam Maschek</a>, Lajos Cseppentő, Márk Matus
+ */
+
+{
+   "sEmptyTable": "Nincs rendelkezésre álló adat",
+   "sInfo": "Találatok: _START_ - _END_ Összesen: _TOTAL_",
+   "sInfoEmpty": "Nulla találat",
+   "sInfoFiltered": "(_MAX_ összes rekord közül szűrve)",
+   "sInfoPostFix": "",
+   "sInfoThousands": " ",
+   "sLengthMenu": "_MENU_ találat oldalanként",
+   "sLoadingRecords": "Betöltés...",
+   "sProcessing": "Feldolgozás...",
+   "sSearch": "Keresés:",
+   "sZeroRecords": "Nincs a keresésnek megfelelő találat",
+   "oPaginate": {
+       "sFirst": "Első",
+       "sPrevious": "Előző",
+       "sNext": "Következő",
+       "sLast": "Utolsó"
+   },
+   "oAria": {
+       "sSortAscending": ": aktiválja a növekvő rendezéshez",
+       "sSortDescending": ": aktiválja a csökkenő rendezéshez"
+   },
+   "select": {
+       "rows": {
+           "_": "%d sor kiválasztva",
+           "0": "",
+           "1": "1 sor kiválasztva"
+       }
+   },
+   "buttons": {
+       "print": "Nyomtatás",
+       "colvis": "Oszlopok",
+       "copy": "Másolás",
+       "copyTitle": "Vágólapra másolás",
+       "copySuccess": {
+           "_": "%d sor másolva",
+           "1": "1 sor másolva"
+       }
+   }
+}

--- a/app/assets/javascripts/dataTables/locales/hy
+++ b/app/assets/javascripts/dataTables/locales/hy
@@ -1,0 +1,30 @@
+/**
+ * Armenian - translation
+ *  @name Armenian
+ *  @anchor Armenian
+ *  @author <a href="http://www.voznisoft.com/">Levon Levonyan</a>
+ */
+
+{
+  "sEmptyTable": "Տվյալները բացակայում են",
+  "sProcessing": "Կատարվում է...",
+  "sInfoThousands":  ",",
+  "sLengthMenu": "Ցուցադրել _MENU_ արդյունքներ մեկ էջում",
+  "sLoadingRecords": "Բեռնվում է ...",
+  "sZeroRecords": "Հարցմանը համապատասխանող արդյունքներ չկան",
+  "sInfo": "Ցուցադրված են _START_-ից _END_ արդյունքները ընդհանուր _TOTAL_-ից",
+  "sInfoEmpty": "Արդյունքներ գտնված չեն",
+  "sInfoFiltered": "(ֆիլտրվել է ընդհանուր _MAX_ արդյունքներից)",
+  "sInfoPostFix":  "",
+  "sSearch": "Փնտրել",
+  "oPaginate": {
+      "sFirst": "Առաջին էջ",
+      "sPrevious": "Նախորդ էջ",
+      "sNext": "Հաջորդ էջ",
+      "sLast": "Վերջին էջ"
+  },
+  "oAria": {
+      "sSortAscending":  ": ակտիվացրեք աճման կարգով դասավորելու համար",
+      "sSortDescending": ": ակտիվացրեք նվազման կարգով դասավորելու համար"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/id
+++ b/app/assets/javascripts/dataTables/locales/id
@@ -1,0 +1,25 @@
+/**
+ * Indonesian translation
+ *  @name Indonesian
+ *  @anchor Indonesian
+ *  @author Cipto Hadi
+ */
+
+{
+	"sEmptyTable":	 "Tidak ada data yang tersedia pada tabel ini",
+	"sProcessing":   "Sedang memproses...",
+	"sLengthMenu":   "Tampilkan _MENU_ entri",
+	"sZeroRecords":  "Tidak ditemukan data yang sesuai",
+	"sInfo":         "Menampilkan _START_ sampai _END_ dari _TOTAL_ entri",
+	"sInfoEmpty":    "Menampilkan 0 sampai 0 dari 0 entri",
+	"sInfoFiltered": "(disaring dari _MAX_ entri keseluruhan)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Cari:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Pertama",
+		"sPrevious": "Sebelumnya",
+		"sNext":     "Selanjutnya",
+		"sLast":     "Terakhir"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/is
+++ b/app/assets/javascripts/dataTables/locales/is
@@ -1,0 +1,30 @@
+/**
+ * Icelandic translation
+ *  @name Icelandic
+ *  @anchor Icelandic
+ *  @author Finnur Kolbeinsson
+ */
+
+{
+	"sEmptyTable":     "Engin gögn eru í þessari töflu",
+	"sInfo":           "Sýni _START_ til _END_ af _TOTAL_ færslum",
+	"sInfoEmpty":      "Sýni 0 til 0 af 0 færslum",
+	"sInfoFiltered":   "(síað út frá _MAX_ færslum)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Sýna _MENU_ færslur",
+	"sLoadingRecords": "Hleð...",
+	"sProcessing":     "Úrvinnsla...",
+	"sSearch":         "Leita:",
+	"sZeroRecords":    "Engar færslur fundust",
+	"oPaginate": {
+		"sFirst":    "Fyrsta",
+		"sLast":     "Síðasta",
+		"sNext":     "Næsta",
+		"sPrevious": "Fyrri"
+	},
+	"oAria": {
+		"sSortAscending":  ": virkja til að raða dálki í hækkandi röð",
+		"sSortDescending": ": virkja til að raða dálki lækkandi í röð"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/it
+++ b/app/assets/javascripts/dataTables/locales/it
@@ -1,0 +1,30 @@
+/**
+ * Italian translation
+ *  @name Italian
+ *  @anchor Italian
+ *  @author Nicola Zecchin & Giulio Quaresima
+ */
+
+{
+	"sEmptyTable":     "Nessun dato presente nella tabella",
+	"sInfo":           "Vista da _START_ a _END_ di _TOTAL_ elementi",
+	"sInfoEmpty":      "Vista da 0 a 0 di 0 elementi",
+	"sInfoFiltered":   "(filtrati da _MAX_ elementi totali)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Visualizza _MENU_ elementi",
+	"sLoadingRecords": "Caricamento...",
+	"sProcessing":     "Elaborazione...",
+	"sSearch":         "Cerca:",
+	"sZeroRecords":    "La ricerca non ha portato alcun risultato.",
+	"oPaginate": {
+		"sFirst":      "Inizio",
+		"sPrevious":   "Precedente",
+		"sNext":       "Successivo",
+		"sLast":       "Fine"
+	},
+	"oAria": {
+		"sSortAscending":  ": attiva per ordinare la colonna in ordine crescente",
+		"sSortDescending": ": attiva per ordinare la colonna in ordine decrescente"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ja
+++ b/app/assets/javascripts/dataTables/locales/ja
@@ -1,0 +1,30 @@
+/**
+ * Japanese translation
+ *  @name Japanese
+ *  @anchor Japanese
+ *  @author <i>yusuke</i> and <a href="https://github.com/wiraqutra">Seigo ISHINO</a>
+ */
+
+{
+  "sEmptyTable":     "テーブルにデータがありません",
+  "sInfo":           " _TOTAL_ 件中 _START_ から _END_ まで表示",
+	"sInfoEmpty":      " 0 件中 0 から 0 まで表示",
+	"sInfoFiltered":   "（全 _MAX_ 件より抽出）",
+  "sInfoPostFix":    "",
+  "sInfoThousands":  ",",
+	"sLengthMenu":     "_MENU_ 件表示",
+  "sLoadingRecords": "読み込み中...",
+	"sProcessing":     "処理中...",
+  "sSearch":         "検索:",
+	"sZeroRecords":    "一致するレコードがありません",
+	"oPaginate": {
+		"sFirst":    "先頭",
+		"sLast":     "最終",
+		"sNext":     "次",
+		"sPrevious": "前"
+	},
+  "oAria": {
+		"sSortAscending":  ": 列を昇順に並べ替えるにはアクティブにする",
+		"sSortDescending": ": 列を降順に並べ替えるにはアクティブにする"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ka
+++ b/app/assets/javascripts/dataTables/locales/ka
@@ -1,0 +1,30 @@
+/**
+ * Georgian translation
+ *  @name Georgian
+ *  @anchor Georgian
+ *  @author Mikheil Nadareishvili, updated by <a href="http://www.brunjadze.xyz/">Mirza Brunjadze</a>
+ */
+
+{
+	"sEmptyTable":     "ცხრილში არ არის მონაცემები",
+	"sInfo":           "ნაჩვენებია ჩანაწერები _START_–დან _END_–მდე, _TOTAL_ ჩანაწერიდან",
+	"sInfoEmpty":      "ნაჩვენებია ჩანაწერები 0–დან 0–მდე, 0 ჩანაწერიდან",
+	"sInfoFiltered":   "(გაფილტრული შედეგი _MAX_ ჩანაწერიდან)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "აჩვენე _MENU_ ჩანაწერი",
+	"sLoadingRecords": "იტვირთება...",
+	"sProcessing":     "მუშავდება...",
+	"sSearch":         "ძიება:",
+	"sZeroRecords":    "არაფერი მოიძებნა",
+	"oPaginate": {
+		"sFirst":    "პირველი",
+		"sLast":     "ბოლო",
+		"sNext":     "შემდეგი",
+		"sPrevious": "წინა"
+	},
+	"oAria": {
+		"sSortAscending":  ": სვეტის დალაგება ზრდის მიხედვით",
+		"sSortDescending": ": სვეტის დალაგება კლების მიხედვით"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/kk
+++ b/app/assets/javascripts/dataTables/locales/kk
@@ -1,0 +1,28 @@
+/**
+ *  Kazakh translation
+ *  @name Kazakh
+ *  @anchor Kazakh
+ *  @author <a href="https://github.com/talgautb">Talgat Uspanov</a>
+ */
+ {
+  "processing": "Күте тұрыңыз...",
+  "search": "Іздеу:",
+  "lengthMenu": "Жазбалар  _MENU_ көрсету",
+  "info": "_TOTAL_ жазбалары бойынша _START_ бастап _END_ дейінгі жазбалар",
+  "infoEmpty": "0 жазбалары бойынша 0 бастап 0 дейінгі жазбалар",
+  "infoFiltered": "(_MAX_ жазбасынан сұрыпталды)",
+  "infoPostFix": "",
+  "loadingRecords": "Жазбалар жүктемесі...",
+  "zeroRecords": "Жазбалар жоқ",
+  "emptyTable": "Кестеде деректер жоқ",
+  "paginate": {
+    "first": "Бірінші",
+    "previous": "Алдыңғысы",
+    "next": "Келесі",
+    "last": "Соңғы"
+  },
+  "aria": {
+    "sortAscending": ": өсімі бойынша бағанды сұрыптау үшін активациялау",
+    "sortDescending": ": кемуі бойынша бағанды сұрыптау үшін активациялау"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/ko
+++ b/app/assets/javascripts/dataTables/locales/ko
@@ -1,0 +1,30 @@
+/**
+ * Korean translation
+ *  @name Korean
+ *  @anchor Korean
+ *  @author WonGoo Lee
+ */
+
+{
+   "sEmptyTable":     "데이터가 없습니다",
+   "sInfo":           "_START_ - _END_ / _TOTAL_",
+   "sInfoEmpty":      "0 - 0 / 0",
+   "sInfoFiltered":   "(총 _MAX_ 개)",
+   "sInfoPostFix":    "",
+   "sInfoThousands":  ",",
+   "sLengthMenu":     "페이지당 줄수 _MENU_",
+   "sLoadingRecords": "읽는중...",
+   "sProcessing":     "처리중...",
+   "sSearch":         "검색:",
+   "sZeroRecords":    "검색 결과가 없습니다",
+   "oPaginate": {
+       "sFirst":    "처음",
+       "sLast":     "마지막",
+       "sNext":     "다음",
+       "sPrevious": "이전"
+   },
+   "oAria": {
+       "sSortAscending":  ": 오름차순 정렬",
+       "sSortDescending": ": 내림차순 정렬"
+   }
+}

--- a/app/assets/javascripts/dataTables/locales/ky
+++ b/app/assets/javascripts/dataTables/locales/ky
@@ -1,0 +1,29 @@
+/**
+ *  @name Kyrgyz
+ *  @anchor Kyrgyz
+ *  @author <a href="https://github.com/nursultan92/">Nursultan Turdaliev</a> and _tynar_
+ */
+
+{
+	"sEmptyTable":     "Таблицада эч кандай берилиш жок",
+	"sInfo":           "Жалпы _TOTAL_ саптын ичинен _START_-саптан _END_-сапка чейинкилер",
+	"sInfoEmpty":      "Жалпы 0 саптын ичинен 0-саптан 0-сапка чейинкилер",
+	"sInfoFiltered":   "(жалпы _MAX_ саптан фильтрленди)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  " ",
+	"sLengthMenu":     "_MENU_ саптан көрсөт",
+	"sLoadingRecords": "Жүктөлүүдө...",
+	"sProcessing":     "Иштеп жатат...",
+	"sSearch":         "Издөө:",
+	"sZeroRecords":    "Туура келген бир да сап жок",
+	"oPaginate": {
+		"sFirst":    "Биринчи",
+		"sLast":     "Акыркы",
+		"sNext":     "Кийинки",
+		"sPrevious": "Мурунку"
+	},
+	"oAria": {
+		"sSortAscending":  ": иретте",
+		"sSortDescending": ": тескери иретте"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/lo
+++ b/app/assets/javascripts/dataTables/locales/lo
@@ -1,0 +1,29 @@
+/**
+ * Lao translation
+ *  @name Lao
+ *  @anchor Lao
+ *  @author Jumbo Liemphachanh
+ */
+{
+    "sEmptyTable":     "ບໍ່ພົບຂໍ້ມູນໃນຕາຕະລາງ",
+    "sInfo":           "ສະແດງ _START_ ເຖິງ _END_ ຈາກ _TOTAL_ ແຖວ",
+    "sInfoEmpty":      "ສະແດງ 0 ເຖິງ 0 ຈາກ 0 ແຖວ",
+    "sInfoFiltered":   "(ກັ່ນຕອງຂໍ້ມູນ _MAX_ ທຸກແຖວ)",
+    "sInfoPostFix":    "",
+    "sInfoThousands":  ",",
+    "sLengthMenu":     "ສະແດງ _MENU_ ແຖວ",
+    "sLoadingRecords": "ກຳລັງໂຫຼດຂໍ້ມູນ...",
+    "sProcessing":     "ກຳລັງດຳເນີນການ...",
+    "sSearch":         "ຄົ້ນຫາ: ",
+    "sZeroRecords":    "ບໍ່ພົບຂໍ້ມູນ",
+    "oPaginate": {
+        "sFirst":    "ໜ້າທຳອິດ",
+    "sPrevious": "ກ່ອນໜ້ານີ້",
+        "sNext":     "ໜ້າຕໍ່ໄປ",
+    "sLast":     "ໜ້າສຸດທ້າຍ"
+    },
+    "oAria": {
+        "sSortAscending":  ": ເປີດໃຊ້ການຈັດລຽງຂໍ້ມູນແຕ່ນ້ອຍຫາໃຫຍ່",
+    "sSortDescending": ": ເປີດໃຊ້ການຈັດລຽງຂໍ້ມູນແຕ່ໃຫຍ່ຫານ້ອຍ"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/lt
+++ b/app/assets/javascripts/dataTables/locales/lt
@@ -1,0 +1,30 @@
+/**
+ * Lithuanian translation
+ *  @name Lithuanian
+ *  @anchor Lithuanian
+ *  @author <a href="http://www.kurdingopinigai.lt">Kęstutis Morkūnas</a>
+ *  @author Algirdas Brazas
+ */
+
+{
+    "sEmptyTable":      "Lentelėje nėra duomenų",
+    "sInfo":            "Rodomi įrašai nuo _START_ iki _END_ iš _TOTAL_ įrašų",
+    "sInfoEmpty":       "Rodomi įrašai nuo 0 iki 0 iš 0",
+    "sInfoFiltered":    "(atrinkta iš _MAX_ įrašų)",
+    "sInfoPostFix":     "",
+    "sInfoThousands":   " ",
+    "sLengthMenu":      "Rodyti _MENU_ įrašus",
+    "sLoadingRecords":  "Įkeliama...",
+    "sProcessing":      "Apdorojama...",
+    "sSearch":          "Ieškoti:",
+    "sThousands":       " ",
+    "sUrl":             "",
+    "sZeroRecords":     "Įrašų nerasta",
+
+    "oPaginate": {
+        "sFirst": "Pirmas",
+        "sPrevious": "Ankstesnis",
+        "sNext": "Tolimesnis",
+        "sLast": "Paskutinis"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/lv
+++ b/app/assets/javascripts/dataTables/locales/lv
@@ -1,0 +1,28 @@
+/**
+ * Latvian translation
+ *  @name Latvian
+ *  @anchor Latvian
+ *  @author Oskars Podans, Ruslans Jermakovičs and Edgars
+ */
+{
+	"processing": "Uzgaidiet ...",
+	"search": "Meklēt:",
+	"lengthMenu": "Rādīt _MENU_ ierakstus",
+	"info": "Parādīti _START_ līdz _END_ no _TOTAL_ ierakstiem",
+	"infoEmpty": "Nav ierakstu",
+	"infoFiltered": "(atlasīts no pavisam _MAX_ ierakstiem)",
+	"infoPostFix": "",
+	"loadingRecords": "Notiek ielāde ...",
+	"zeroRecords": "Nav atrasti vaicājumam atbilstoši ieraksti",
+	"emptyTable": "Tabulā nav datu",
+	"paginate": {
+		"first": "Pirmā",
+		"previous": "Iepriekšējā",
+		"next": "Nākošā",
+		"last": "Pēdējā"
+	},
+	"aria": {
+		"sortAscending": ": aktivizēt kolonnu, lai kārtotu augoši",
+		"sortDescending": ": aktivizēt kolonnu, lai kārtotu dilstoši"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/mk
+++ b/app/assets/javascripts/dataTables/locales/mk
@@ -1,0 +1,26 @@
+/**
+ * Macedonian translation
+ *  @name Macedonian
+ *  @anchor Macedonian
+ *  @author Bojan Petkovski
+ */
+
+{
+	"sProcessing":     "Процесирање...",
+	"sLengthMenu":     "Прикажи _MENU_ записи",
+	"sZeroRecords":    "Не се пронајдени записи",
+	"sEmptyTable":	   "Нема податоци во табелата",
+	"sLoadingRecords": "Вчитување...",
+	"sInfo":           "Прикажани _START_ до _END_ од _TOTAL_ записи",
+	"sInfoEmpty":      "Прикажани 0 до 0 од 0 записи",
+	"sInfoFiltered":   "(филтрирано од вкупно _MAX_ записи)",
+	"sInfoPostFix":    "",
+	"sSearch":         "Барај",
+	"sUrl": "",
+	"oPaginate": {
+		"sFirst":      "Почетна",
+		"sPrevious":   "Претходна",
+		"sNext":       "Следна",
+		"sLast":       "Последна"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/mn
+++ b/app/assets/javascripts/dataTables/locales/mn
@@ -1,0 +1,30 @@
+/**
+ * Mongolian - Монгол хэлний орчуулга
+ *  @name Mongolian
+ *  @anchor Mongolian
+ *  @author <a href="http://www.Batmandakh.com/">Batmandakh Erdenebileg</a>
+ */
+
+{
+	"sEmptyTable":     "Хүснэгт хоосон байна",
+        "sInfo":           "Нийт _TOTAL_ бичлэгээс _START_ - _END_ харуулж байна",
+        "sInfoEmpty":      "Тохирох үр дүн алга",
+        "sInfoFiltered":   "(нийт _MAX_ бичлэгээс шүүв)",
+        "sInfoPostFix":    "",
+        "sInfoThousands":  ",",
+        "sLengthMenu":     "Дэлгэцэд _MENU_ бичлэг харуулна",
+        "sLoadingRecords": "Ачааллаж байна...",
+        "sProcessing":     "Боловсруулж байна...",
+        "sSearch":         "Хайлт:",
+        "sZeroRecords":    "Тохирох бичлэг олдсонгүй",
+        "oPaginate": {
+        	"sFirst":    "Эхнийх",
+                "sLast":     "Сүүлийнх",
+                "sNext":     "Өмнөх",
+                "sPrevious": "Дараах"
+        },
+        "oAria": {
+                "sSortAscending":  ": цагаан толгойн дарааллаар эрэмбэлэх",
+                "sSortDescending": ": цагаан толгойн эсрэг дарааллаар эрэмбэлэх"
+        }
+}

--- a/app/assets/javascripts/dataTables/locales/ms
+++ b/app/assets/javascripts/dataTables/locales/ms
@@ -1,0 +1,30 @@
+/**
+ * Malay translation
+ *  @name Malay
+ *  @anchor Malay
+ *  @author Mohamad Zharif
+ */
+
+{
+	"sEmptyTable":		"Tiada data",
+	"sInfo":         	"Paparan dari _START_ hingga _END_ dari _TOTAL_ rekod",
+	"sInfoEmpty":    	"Paparan 0 hingga 0 dari 0 rekod",
+	"sInfoFiltered": 	"(Ditapis dari jumlah _MAX_ rekod)",
+	"sInfoPostFix":  	"",
+	"sInfoThousands":  	",",
+	"sLengthMenu":		"Papar _MENU_ rekod",
+	"sLoadingRecords": 	"Diproses...",
+	"sProcessing":		"Sedang diproses...",
+	"sSearch":       	"Carian:",
+   "sZeroRecords":  	"Tiada padanan rekod yang dijumpai.",
+   "oPaginate": {
+       "sFirst":    	"Pertama",
+       "sPrevious": 	"Sebelum",
+       "sNext":     	"Kemudian",
+       "sLast":     	"Akhir"
+   },
+   "oAria": {
+       "sSortAscending":  ": diaktifkan kepada susunan lajur menaik",
+       "sSortDescending": ": diaktifkan kepada susunan lajur menurun"
+   }
+}

--- a/app/assets/javascripts/dataTables/locales/ne
+++ b/app/assets/javascripts/dataTables/locales/ne
@@ -1,0 +1,31 @@
+/**
+ * Nepali
+ *  @name Nepali
+ *  @anchor Nepali
+ *  @author Bishwo Adhikari
+ */
+
+{
+	"sEmptyTable":	 "टेबलमा डाटा उपलब्ध भएन",
+	"sInfo":         "_TOTAL_ रेकर्ड मध्य _START_ देखि _END_ रेकर्ड देखाउंदै",
+	"sInfoEmpty":    "0 मध्य 0 देखि 0 रेकर्ड देखाउंदै",
+	"sInfoFiltered": "(_MAX_ कुल रेकर्डबाट छनौट गरिएको)",
+	"sInfoPostFix":  "",
+	"sInfoThousands": ",",
+	"sLengthMenu":   " _MENU_ रेकर्ड देखाउने ",
+	"sLoadingRecords": "लोड हुँदैछ...",
+	"sProcessing":   "प्रगति हुदैंछ ...",
+	"sSearch":       "खोजी:",
+	"sUrl":          "",
+	"sZeroRecords":  "कुनै मिल्ने रेकर्ड फेला परेन",
+	"oPaginate": {
+		"sFirst":    "प्रथम",
+		"sPrevious": "पछिल्लो",
+		"sNext":     "अघिल्लो",
+		"sLast":     "अन्तिम"
+	},
+	"oAria": {
+		"sSortAscending": ": अगाडिबाट अक्षरात्मक रूपमा क्रमबद्ध गराउने",
+		"sSortDescending": ": पछाडिबाट अक्षरात्मक रूपमा क्रमबद्ध गराउने"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/nl
+++ b/app/assets/javascripts/dataTables/locales/nl
@@ -1,0 +1,30 @@
+/**
+ * Dutch translation
+ *  @name Dutch
+ *  @anchor Dutch
+ *  @author <a href="http://www.blikgooien.nl/">Erwin Kerk</a> and <i>ashwin</i>
+ */
+
+{
+    "sProcessing": "Bezig...",
+    "sLengthMenu": "_MENU_ resultaten weergeven",
+    "sZeroRecords": "Geen resultaten gevonden",
+    "sInfo": "_START_ tot _END_ van _TOTAL_ resultaten",
+    "sInfoEmpty": "Geen resultaten om weer te geven",
+    "sInfoFiltered": " (gefilterd uit _MAX_ resultaten)",
+    "sInfoPostFix": "",
+    "sSearch": "Zoeken:",
+    "sEmptyTable": "Geen resultaten aanwezig in de tabel",
+    "sInfoThousands": ".",
+    "sLoadingRecords": "Een moment geduld aub - bezig met laden...",
+    "oPaginate": {
+        "sFirst": "Eerste",
+        "sLast": "Laatste",
+        "sNext": "Volgende",
+        "sPrevious": "Vorige"
+    },
+    "oAria": {
+        "sSortAscending":  ": activeer om kolom oplopend te sorteren",
+        "sSortDescending": ": activeer om kolom aflopend te sorteren"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/pl
+++ b/app/assets/javascripts/dataTables/locales/pl
@@ -1,0 +1,30 @@
+/**
+ * Polish translation
+ *  @name Polish
+ *  @anchor Polish
+ *  @author Tomasz Kowalski
+ *  @author Michał Grzelak
+ */
+
+{
+	"processing":     "Przetwarzanie...",
+	"search":         "Szukaj:",
+	"lengthMenu":     "Pokaż _MENU_ pozycji",
+	"info":           "Pozycje od _START_ do _END_ z _TOTAL_ łącznie",
+	"infoEmpty":      "Pozycji 0 z 0 dostępnych",
+	"infoFiltered":   "(filtrowanie spośród _MAX_ dostępnych pozycji)",
+	"infoPostFix":    "",
+	"loadingRecords": "Wczytywanie...",
+	"zeroRecords":    "Nie znaleziono pasujących pozycji",
+	"emptyTable":     "Brak danych",
+	"paginate": {
+		"first":      "Pierwsza",
+		"previous":   "Poprzednia",
+		"next":       "Następna",
+		"last":       "Ostatnia"
+	},
+	"aria": {
+		"sortAscending": ": aktywuj, by posortować kolumnę rosnąco",
+		"sortDescending": ": aktywuj, by posortować kolumnę malejąco"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ps
+++ b/app/assets/javascripts/dataTables/locales/ps
@@ -1,0 +1,30 @@
+/**
+ * Pashto translation
+ *  @name Pashto
+ *  @anchor Pashto
+ *  @author <a href="http://mbrig.com/">MBrig | Muhammad Nasir Rahimi</a>
+ */
+
+{
+	"sEmptyTable":     "جدول خالي دی",
+	"sInfo":           "د _START_ څخه تر _END_ پوري، له ټولو _TOTAL_ څخه",
+	"sInfoEmpty":      "د 0 څخه تر 0 پوري، له ټولو 0 څخه",
+	"sInfoFiltered":   "(لټول سوي له ټولو _MAX_ څخه)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "_MENU_ کتاره وښايه",
+	"sLoadingRecords": "منتظر اوسئ...",
+	"sProcessing":     "منتظر اوسئ...",
+	"sSearch":         "لټون:",
+	"sZeroRecords":    "د لټون مطابق معلومات و نه موندل سول",
+	"oPaginate": {
+		"sFirst":    "لومړۍ",
+		"sLast":     "وروستۍ",
+		"sNext":     "بله",
+		"sPrevious": "شاته"
+	},
+	"oAria": {
+		"sSortAscending":  ": په صعودي ډول مرتبول",
+		"sSortDescending": ": په نزولي ډول مرتبول"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/pt
+++ b/app/assets/javascripts/dataTables/locales/pt
@@ -1,0 +1,29 @@
+/**
+ * Portuguese translation
+ *  @name Portuguese
+ *  @anchor Portuguese
+ *  @author Nuno Felicio
+ */
+
+{
+	"sEmptyTable":   "Não foi encontrado nenhum registo",
+	"sProcessing":   "A carregar...",
+	"sLengthMenu":   "Mostrar _MENU_ registos",
+	"sZeroRecords":  "Não foram encontrados resultados",
+	"sInfo":         "Mostrando de _START_ até _END_ de _TOTAL_ registos",
+	"sInfoEmpty":    "Mostrando de 0 até 0 de 0 registos",
+	"sInfoFiltered": "(filtrado de _MAX_ registos no total)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Procurar:",
+	"sUrl":          "",
+	"oPaginate": {
+	    "sFirst":    "Primeiro",
+	    "sPrevious": "Anterior",
+	    "sNext":     "Seguinte",
+	    "sLast":     "Último"
+	},
+	"oAria": {
+	    "sSortAscending":  ": Ordenar colunas de forma ascendente",
+	    "sSortDescending": ": Ordenar colunas de forma descendente"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/renamer.rb
+++ b/app/assets/javascripts/dataTables/locales/renamer.rb
@@ -1,0 +1,12 @@
+# Get the translations from:
+# https://github.com/DataTables/Plugins/tree/master/i18n
+
+require 'i18n_data'
+
+(Dir['*'] - ['renamer.rb']).each do |f|
+  code = I18nData.language_code(File.basename(f, ".*"))
+
+  next if code.nil?
+
+  File.rename(f, code.downcase)
+end

--- a/app/assets/javascripts/dataTables/locales/ro
+++ b/app/assets/javascripts/dataTables/locales/ro
@@ -1,0 +1,24 @@
+/**
+ * Romanian translation
+ *  @name Romanian
+ *  @anchor Romanian
+ *  @author <a href="http://www.jurubita.ro/">Alexandru Jurubita</a>
+ */
+
+{
+	"sProcessing":   "Procesează...",
+	"sLengthMenu":   "Afișează _MENU_ înregistrări pe pagină",
+	"sZeroRecords":  "Nu am găsit nimic - ne pare rău",
+	"sInfo":         "Afișate de la _START_ la _END_ din _TOTAL_ înregistrări",
+	"sInfoEmpty":    "Afișate de la 0 la 0 din 0 înregistrări",
+	"sInfoFiltered": "(filtrate dintr-un total de _MAX_ înregistrări)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Caută:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Prima",
+		"sPrevious": "Precedenta",
+		"sNext":     "Următoarea",
+		"sLast":     "Ultima"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ru
+++ b/app/assets/javascripts/dataTables/locales/ru
@@ -1,0 +1,30 @@
+/**
+ * Russian translation
+ *  @name Russian
+ *  @anchor Russian
+ *  @author Tjoma
+ *  @autor aspyatkin 
+ */
+
+{
+  "processing": "Подождите...",
+  "search": "Поиск:",
+  "lengthMenu": "Показать _MENU_ записей",
+  "info": "Записи с _START_ до _END_ из _TOTAL_ записей",
+  "infoEmpty": "Записи с 0 до 0 из 0 записей",
+  "infoFiltered": "(отфильтровано из _MAX_ записей)",
+  "infoPostFix": "",
+  "loadingRecords": "Загрузка записей...",
+  "zeroRecords": "Записи отсутствуют.",
+  "emptyTable": "В таблице отсутствуют данные",
+  "paginate": {
+    "first": "Первая",
+    "previous": "Предыдущая",
+    "next": "Следующая",
+    "last": "Последняя"
+  },
+  "aria": {
+    "sortAscending": ": активировать для сортировки столбца по возрастанию",
+    "sortDescending": ": активировать для сортировки столбца по убыванию"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/si
+++ b/app/assets/javascripts/dataTables/locales/si
@@ -1,0 +1,30 @@
+/**
+ * Sinhala translation
+ *  @name Sinhala
+ *  @anchor Sinhala
+ *  @author Isuru Sampath Ratnayake
+ */
+
+{
+	"sEmptyTable":     "වගුවේ දත්ත කිසිවක් නොමැත",
+	"sInfo":           "_TOTAL_ න් _START_ සිට _END_ දක්වා",
+	"sInfoEmpty":      "0 න් 0 සිට 0 දක්වා",
+	"sInfoFiltered":   "(_MAX_ න් තෝරාගත් )",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "_MENU_ ක් පෙන්වන්න",
+	"sLoadingRecords": "පූරණය වෙමින් පවතී...",
+	"sProcessing":     "සැකසෙමින් පවතී...",
+	"sSearch":         "සොයන්න :",
+	"sZeroRecords":    "ගැලපෙන වාර්තා නොමැත.",
+	"oPaginate": {
+		"sFirst":    "පළමු",
+		"sLast":     "අන්තිම",
+		"sNext":     "ඊළග",
+		"sPrevious": "පසුගිය"
+	},
+	"oAria": {
+		"sSortAscending":  ": තීරුව ආරෝහනව තෝරන්න",
+		"sSortDescending": ": තීරුව අවරෝහනව තෝරන්න"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/sk
+++ b/app/assets/javascripts/dataTables/locales/sk
@@ -1,0 +1,30 @@
+/**
+ * Slovak translation
+ *  @name Slovak
+ *  @anchor Slovak
+ *  @author <a href="https://github.com/dlugos">Ivan Dlugoš</a>
+ *  @author (original translation) <a href="http://miskerik.com/">Maroš Miškerik</a>
+ */
+{
+	"sEmptyTable":     "Nie sú k dispozícii žiadne dáta",
+	"sInfo":           "Záznamy _START_ až _END_ z celkom _TOTAL_",
+	"sInfoEmpty":      "Záznamy 0 až 0 z celkom 0 ",
+	"sInfoFiltered":   "(vyfiltrované spomedzi _MAX_ záznamov)",
+	"sInfoPostFix":    "",
+  	"sInfoThousands":  ",",
+	"sLengthMenu":     "Zobraz _MENU_ záznamov",
+	"sLoadingRecords": "Načítavam...",
+	"sProcessing":     "Spracúvam...",
+	"sSearch":         "Hľadať:",
+	"sZeroRecords":    "Nenašli sa žiadne vyhovujúce záznamy",
+	"oPaginate": {
+		"sFirst":    "Prvá",
+		"sLast":     "Posledná",
+		"sNext":     "Nasledujúca",
+		"sPrevious": "Predchádzajúca"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivujte na zoradenie stĺpca vzostupne",
+		"sSortDescending": ": aktivujte na zoradenie stĺpca zostupne"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/sl
+++ b/app/assets/javascripts/dataTables/locales/sl
@@ -1,0 +1,30 @@
+/**
+ * Slovenian translation
+ *  @name Slovenian
+ *  @anchor Slovenian
+ *  @author Marko Kroflic, Blaž Brenčič and Andrej Florjančič
+ */
+
+{
+	"sEmptyTable": "Nobenih podatkov ni na voljo",
+	"sInfo": "Prikazujem _START_ do _END_ od _TOTAL_ zapisov",
+	"sInfoEmpty": "Prikazujem 0 do 0 od 0 zapisov",
+	"sInfoFiltered": "(filtrirano od _MAX_ vseh zapisov)",
+	"sInfoPostFix": "",
+	"sInfoThousands": ",",
+	"sLengthMenu": "Prikaži _MENU_ zapisov",
+	"sLoadingRecords": "Nalagam...",
+	"sProcessing": "Obdelujem...",
+	"sSearch": "Išči:",
+	"sZeroRecords": "Nobeden zapis ne ustreza",
+	"oPaginate": {
+		"sFirst": "Prvi",
+		"sLast": "Zadnji",
+		"sNext": "Nasl.",
+		"sPrevious": "Pred."
+	},
+	"oAria": {
+		"sSortAscending": ": vključite za naraščujoči sort",
+		"sSortDescending": ": vključite za padajoči sort"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/sq
+++ b/app/assets/javascripts/dataTables/locales/sq
@@ -1,0 +1,30 @@
+/**
+ * Albanian translation
+ *  @name Albanian
+ *  @anchor Albanian
+ *  @author Besnik Belegu
+ */
+
+{
+   "sEmptyTable":     "Nuk ka asnjë të dhënë në tabele",
+   "sInfo":           "Duke treguar _START_ deri _END_ prej _TOTAL_ reshtave",
+   "sInfoEmpty":      "Duke treguar 0 deri 0 prej 0 reshtave",
+   "sInfoFiltered":   "(të filtruara nga gjithësej _MAX_  reshtave)",
+   "sInfoPostFix":    "",
+   "sInfoThousands":  ",",
+   "sLengthMenu":     "Shiko _MENU_ reshta",
+   "sLoadingRecords": "Duke punuar...",
+   "sProcessing":     "Duke procesuar...",
+   "sSearch":         "Kërkoni:",
+   "sZeroRecords":    "Asnjë e dhënë nuk u gjet",
+   "oPaginate": {
+       "sFirst":    "E para",
+       "sLast":     "E Fundit",
+       "sNext":     "Tjetra",
+       "sPrevious": "E Kaluara"
+   },
+   "oAria": {
+       "sSortAscending":  ": aktivizo për të sortuar kolumnin me vlera në ngritje",
+       "sSortDescending": ": aktivizo për të sortuar kolumnin me vlera në zbritje"
+   }
+}

--- a/app/assets/javascripts/dataTables/locales/sr
+++ b/app/assets/javascripts/dataTables/locales/sr
@@ -1,0 +1,30 @@
+/**
+ * Serbian
+ *  @name Serbian
+ *  @anchor Serbian
+ *  @author <a href="http://blog.trk.in.rs">duleorlovic</a>
+ */
+
+{
+	"sEmptyTable":     "Нема података у табели",
+	"sInfo":           "Приказ _START_ до _END_ од укупно _TOTAL_ записа",
+	"sInfoEmpty":      "Приказ 0 до 0 од укупно 0 записа",
+	"sInfoFiltered":   "(филтрирано од укупно _MAX_ записа)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Прикажи _MENU_ записа",
+	"sLoadingRecords": "Учитавање...",
+	"sProcessing":     "Обрада...",
+	"sSearch":         "Претрага:",
+	"sZeroRecords":    "Нису пронађени одговарајући записи",
+	"oPaginate": {
+		"sFirst":    "Почетна",
+		"sLast":     "Последња",
+		"sNext":     "Следећа",
+		"sPrevious": "Предходна"
+	},
+	"oAria": {
+		"sSortAscending":  ": активирајте да сортирате колону узлазно",
+		"sSortDescending": ": активирајте да сортирате колону силазно"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/sv
+++ b/app/assets/javascripts/dataTables/locales/sv
@@ -1,0 +1,30 @@
+/**
+ * Swedish translation
+ * @name Swedish
+ * @anchor Swedish
+ * @author <a href="http://www.kmmtiming.se/">Kristoffer Karlström</a>
+ */
+
+{
+  "sEmptyTable": "Tabellen innehåller ingen data",
+  "sInfo": "Visar _START_ till _END_ av totalt _TOTAL_ rader",
+  "sInfoEmpty": "Visar 0 till 0 av totalt 0 rader",
+  "sInfoFiltered": "(filtrerade från totalt _MAX_ rader)",
+  "sInfoPostFix": "",
+  "sInfoThousands": " ",
+  "sLengthMenu": "Visa _MENU_ rader",
+  "sLoadingRecords": "Laddar...",
+  "sProcessing": "Bearbetar...",
+  "sSearch": "Sök:",
+  "sZeroRecords": "Hittade inga matchande resultat",
+  "oPaginate": {
+    "sFirst": "Första",
+    "sLast": "Sista",
+    "sNext": "Nästa",
+    "sPrevious": "Föregående"
+  },
+  "oAria": {
+    "sSortAscending": ": aktivera för att sortera kolumnen i stigande ordning",
+    "sSortDescending": ": aktivera för att sortera kolumnen i fallande ordning"
+  }
+}

--- a/app/assets/javascripts/dataTables/locales/sw
+++ b/app/assets/javascripts/dataTables/locales/sw
@@ -1,0 +1,30 @@
+/**
+ * Swahili translation
+ *  @name Swahili
+ *  @anchor Swahili
+ *  @author <a href="http://zoop.co.tz/schoolpesa/">Roy Owino</a>
+ */
+
+{
+	"sEmptyTable":     "Hakuna data iliyo patikana",
+	"sInfo":           "Inaonyesha _START_ mpaka _END_ ya matokeo _TOTAL_",
+	"sInfoEmpty":      "Inaonyesha 0 hadi 0 ya matokeo 0",
+	"sInfoFiltered":   "(uschujo kutoka matokeo idadi _MAX_)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "Onyesha _MENU_ matokeo",
+	"sLoadingRecords": "Inapakia...",
+	"sProcessing":     "Processing...",
+	"sSearch":         "Tafuta:",
+	"sZeroRecords":    "Rekodi vinavyolingana haziku patikana",
+	"oPaginate": {
+		"sFirst":    "Mwanzo",
+		"sLast":     "Mwisho",
+		"sNext":     "Ijayo",
+		"sPrevious": "Kabla"
+	},
+	"oAria": {
+		"sSortAscending": ": seti kulainisha sanjari kwa mtindo wa upandaji",
+		"sSortDescending": ": seti kulainisha sanjari kwa mtindo wa mteremko"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ta
+++ b/app/assets/javascripts/dataTables/locales/ta
@@ -1,0 +1,30 @@
+/**
+ * Tamil translation
+ *  @name Tamil
+ *  @anchor Tamil
+ *  @author Sam Arul Raj
+ */
+
+{
+	"sEmptyTable":     "அட்டவணையில் தரவு கிடைக்கவில்லை",
+	"sInfo":           "உள்ளீடுகளை் _START_ முதல _END_ உள்ள _TOTAL_ காட்டும்",
+	"sInfoEmpty":      "0 உள்ளீடுகளை 0 0 காட்டும்",
+	"sInfoFiltered":   "(_MAX_ மொத்த உள்ளீடுகளை இருந்து வடிகட்டி)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "_MENU_ காண்பி",
+	"sLoadingRecords": "ஏற்றுகிறது ...",
+	"sProcessing":     "செயலாக்க ...",
+	"sSearch":         "தேடல்:",
+	"sZeroRecords":    "பொருத்தமான பதிவுகள் இல்லை",
+	"oPaginate": {
+		"sFirst":    "முதல்",
+		"sLast":     "இறுதி",
+		"sNext":     "அடுத்து",
+		"sPrevious": "முந்தைய"
+	},
+	"oAria": {
+		"sSortAscending":  ": நிரலை ஏறுவரிசையில் வரிசைப்படுத்த செயல்படுத்த",
+		"sSortDescending": ": நிரலை இறங்கு வரிசைப்படுத்த செயல்படுத்த"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/te
+++ b/app/assets/javascripts/dataTables/locales/te
@@ -1,0 +1,29 @@
+/**
+ * Telugu translation (te, te-IN)
+ *  @name Telugu
+ *  @anchor Telugu
+ *  @author <a href="https://in.linkedin.com/in/srinivas-rathikrindi-0405973a">Srinivas Rathikrindi</a>
+ **/ 
+{
+    "sEmptyTable": "పట్టికలో డేటా లేదు.",
+    "sInfo": "మొత్తం _TOTAL_ ఎంట్రీలులో _START_ నుండి _END_ వరకు చూపిస్తున్నాం",
+    "sInfoEmpty": "చూపిస్తున్నాం 0 నుండి 0 వరకు 0 ఎంట్రీలు లో",
+    "sInfoFiltered": "( _MAX_ ఎంట్రీలులో నుండి వడపోయాబడినవి)",
+    "sInfoPostFix": "",
+    "sInfoThousands": ",",
+    "sLengthMenu": " _MENU_ ఎంట్రీలు చూపించు",
+    "sLoadingRecords": "లోడ్ అవుతుంది ...",
+    "sProcessing": "ప్రాసెస్ చేయబడుతుంది...",
+    "sSearch": "వెతుకు:",
+    "sZeroRecords": "మ్యాచింగ్ రికార్డులు లేవు",
+    "oPaginate": {
+        "sFirst": "మొదటి",
+        "sLast": "చివరి",
+        "sNext": "తర్వాత",
+        "sPrevious": "మునుపటి"
+    },
+    "oAria": {
+        "sSortAscending": ": నిలువరుసను ఆరోహణ క్రమం అమర్చండి",
+        "sSortDescending": ": నిలువరుసను అవరోహణ క్రమం అమర్చండి"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/th
+++ b/app/assets/javascripts/dataTables/locales/th
@@ -1,0 +1,30 @@
+/**
+ * Thai translation
+ *  @name Thai
+ *  @anchor Thai
+ *  @author Thanva Thonglor , <a href="http://auycro.github.io/about/">Gumpanat Keardkeawfa</a>
+ */
+
+{
+    "sEmptyTable":     "ไม่มีข้อมูลในตาราง",
+    "sInfo":           "แสดง _START_ ถึง _END_ จาก _TOTAL_ แถว",
+    "sInfoEmpty":      "แสดง 0 ถึง 0 จาก 0 แถว",
+    "sInfoFiltered":   "(กรองข้อมูล _MAX_ ทุกแถว)",
+    "sInfoPostFix":    "",
+    "sInfoThousands":  ",",
+    "sLengthMenu":     "แสดง _MENU_ แถว",
+    "sLoadingRecords": "กำลังโหลดข้อมูล...",
+    "sProcessing":     "กำลังดำเนินการ...",
+    "sSearch":         "ค้นหา: ",
+    "sZeroRecords":    "ไม่พบข้อมูล",
+    "oPaginate": {
+        "sFirst":    "หน้าแรก",
+	"sPrevious": "ก่อนหน้า",
+        "sNext":     "ถัดไป",
+	"sLast":     "หน้าสุดท้าย"
+    },
+    "oAria": {
+        "sSortAscending":  ": เปิดใช้งานการเรียงข้อมูลจากน้อยไปมาก",
+	"sSortDescending": ": เปิดใช้งานการเรียงข้อมูลจากมากไปน้อย"
+    }
+}

--- a/app/assets/javascripts/dataTables/locales/tl
+++ b/app/assets/javascripts/dataTables/locales/tl
@@ -1,0 +1,24 @@
+/**
+ * Filipino translation
+ *  @name Filipino
+ *  @anchor Filipino
+ *  @author <a href="http://citi360.com/">Citi360</a>
+ */
+
+{
+	"sProcessing":   "Pagproseso...",
+	"sLengthMenu":   "Ipakita _MENU_ entries",
+	"sZeroRecords":  "Walang katugmang  mga talaan  na natagpuan",
+	"sInfo":         "Ipinapakita ang  _START_  sa _END_ ng _TOTAL_ entries",
+	"sInfoEmpty":    "Ipinapakita ang 0-0 ng 0 entries",
+	"sInfoFiltered": "(na-filter mula _MAX_ kabuuang entries)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Paghahanap:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Unang",
+		"sPrevious": "Nakaraan",
+		"sNext":     "Susunod",
+		"sLast":     "Huli"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/tr
+++ b/app/assets/javascripts/dataTables/locales/tr
@@ -1,0 +1,38 @@
+/**
+ * Turkish translation
+ *  @name Turkish
+ *  @anchor Turkish
+ *  @author Umit Gorkem & Erdal TAŞKESEN
+ */
+
+{
+	"sDecimal":        ",",
+	"sEmptyTable":     "Tabloda herhangi bir veri mevcut değil",
+	"sInfo":           "_TOTAL_ kayıttan _START_ - _END_ arasındaki kayıtlar gösteriliyor",
+	"sInfoEmpty":      "Kayıt yok",
+	"sInfoFiltered":   "(_MAX_ kayıt içerisinden bulunan)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Sayfada _MENU_ kayıt göster",
+	"sLoadingRecords": "Yükleniyor...",
+	"sProcessing":     "İşleniyor...",
+	"sSearch":         "Ara:",
+	"sZeroRecords":    "Eşleşen kayıt bulunamadı",
+	"oPaginate": {
+		"sFirst":    "İlk",
+		"sLast":     "Son",
+		"sNext":     "Sonraki",
+		"sPrevious": "Önceki"
+	},
+	"oAria": {
+		"sSortAscending":  ": artan sütun sıralamasını aktifleştir",
+		"sSortDescending": ": azalan sütun sıralamasını aktifleştir"
+	},
+	"select": {
+		"rows": {
+			"_": "%d kayıt seçildi",
+			"0": "",
+			"1": "1 kayıt seçildi"
+		}
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/uk
+++ b/app/assets/javascripts/dataTables/locales/uk
@@ -1,0 +1,28 @@
+/**
+ * Ukrainian translation
+ *  @name Ukrainian
+ *  @anchor Ukrainian
+ *  @author <i>antyrat</i>
+ */
+
+{
+	"sProcessing":   "Зачекайте...",
+	"sLengthMenu":   "Показати _MENU_ записів",
+	"sZeroRecords":  "Записи відсутні.",
+	"sInfo":         "Записи з _START_ по _END_ із _TOTAL_ записів",
+	"sInfoEmpty":    "Записи з 0 по 0 із 0 записів",
+	"sInfoFiltered": "(відфільтровано з _MAX_ записів)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Пошук:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst": "Перша",
+		"sPrevious": "Попередня",
+		"sNext": "Наступна",
+		"sLast": "Остання"
+	},
+	"oAria": {
+		"sSortAscending":  ": активувати для сортування стовпців за зростанням",
+		"sSortDescending": ": активувати для сортування стовпців за спаданням"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/ur
+++ b/app/assets/javascripts/dataTables/locales/ur
@@ -1,0 +1,24 @@
+/**
+ * Urdu translation
+ *  @name Urdu
+ *  @anchor Urdu
+ *  @author Zafar Subzwari
+ */
+
+{
+	"sProcessing":   "ہے جاري عملدرامد...",
+	"sLengthMenu":   "دکہائين شقيں کي (_MENU_) فہرست",
+	"sZeroRecords":  "ملے نہيں مفروضات جلتے ملتے کوئ",
+	"sInfo":         "فہرست کي تک _END_ سے _START_ سے ميں _TOTAL_ فہرست پوري ہے نظر پيش",
+	"sInfoEmpty":    "فہرست کي تک 0 سے 0 سے ميں 0 قل ہے نظر پيشّ",
+	"sInfoFiltered": "(فہرست ہوئ چھني سے ميں _MAX_ قل)",
+	"sInfoPostFix":  "",
+	"sSearch":       "کرو تلاش:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "پہلا",
+		"sPrevious": "پچہلا",
+		"sNext":     "اگلا",
+		"sLast":     "آخري"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/uz
+++ b/app/assets/javascripts/dataTables/locales/uz
@@ -1,0 +1,29 @@
+/**
+ * Uzbek translation
+ *  @name Uzbek
+ *  @anchor Uzbek
+ *  @author <a href="http://davlat.info">Farkhod Dadajanov</a>
+ */
+
+{
+	"sEmptyTable":   	"Ma'lumot yo'q",
+	"sInfo":         	"Umumiy _TOTAL_ yozuvlarlardan _START_ dan _END_ gachasi ko'rsatilmoqda",
+	"sInfoEmpty":    	"Umumiy 0 yozuvlardan 0 dan 0 gachasi ko'rsatilmoqda",
+	"sInfoFiltered": 	"(_MAX_ yozuvlardan filtrlandi)",
+	"sInfoPostFix":  	"",
+	"sLengthMenu":   	"_MENU_ ta yozuvlarni ko'rsat",
+	"sLoadingRecords": 	"Yozuvlar yuklanmoqda...",
+	"sProcessing":     	"Ishlayapman...",
+	"sSearch":       	"Izlash:",
+	"sZeroRecords":  	"Ma'lumot yo'q.",
+	"oPaginate": {
+		"sFirst": 		"Birinchi",
+		"sPrevious": 	"Avvalgi",
+		"sNext": 		"Keyingi",
+		"sLast": 		"Son'ggi"
+	},
+	"oAria": {
+		"sSortAscending":  ": to'g'ri tartiblash",
+		"sSortDescending": ": teskari tartiblash"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/vi
+++ b/app/assets/javascripts/dataTables/locales/vi
@@ -1,0 +1,24 @@
+/**
+ * Vietnamese translation
+ *  @name Vietnamese
+ *  @anchor Vietnamese
+ *  @author Trinh Phuoc Thai
+ */
+
+{
+	"sProcessing":   "Đang xử lý...",
+	"sLengthMenu":   "Xem _MENU_ mục",
+	"sZeroRecords":  "Không tìm thấy dòng nào phù hợp",
+	"sInfo":         "Đang xem _START_ đến _END_ trong tổng số _TOTAL_ mục",
+	"sInfoEmpty":    "Đang xem 0 đến 0 trong tổng số 0 mục",
+	"sInfoFiltered": "(được lọc từ _MAX_ mục)",
+	"sInfoPostFix":  "",
+	"sSearch":       "Tìm:",
+	"sUrl":          "",
+	"oPaginate": {
+		"sFirst":    "Đầu",
+		"sPrevious": "Trước",
+		"sNext":     "Tiếp",
+		"sLast":     "Cuối"
+	}
+}

--- a/app/assets/javascripts/dataTables/locales/zh
+++ b/app/assets/javascripts/dataTables/locales/zh
@@ -1,0 +1,31 @@
+/**
+ * Chinese translation
+ *  @name Chinese
+ *  @anchor Chinese
+ *  @author <a href="http://docs.jquery.com/UI">Chi Cheng</a>
+ */
+
+{
+	"sProcessing":   "处理中...",
+	"sLengthMenu":   "显示 _MENU_ 项结果",
+	"sZeroRecords":  "没有匹配结果",
+	"sInfo":         "显示第 _START_ 至 _END_ 项结果，共 _TOTAL_ 项",
+	"sInfoEmpty":    "显示第 0 至 0 项结果，共 0 项",
+	"sInfoFiltered": "(由 _MAX_ 项结果过滤)",
+	"sInfoPostFix":  "",
+	"sSearch":       "搜索:",
+	"sUrl":          "",
+	"sEmptyTable":     "表中数据为空",
+	"sLoadingRecords": "载入中...",
+	"sInfoThousands":  ",",
+	"oPaginate": {
+		"sFirst":    "首页",
+		"sPrevious": "上页",
+		"sNext":     "下页",
+		"sLast":     "末页"
+	},
+	"oAria": {
+		"sSortAscending":  ": 以升序排列此列",
+		"sSortDescending": ": 以降序排列此列"
+	}
+}

--- a/app/assets/javascripts/effective_datatables/initialize.js.coffee
+++ b/app/assets/javascripts/effective_datatables/initialize.js.coffee
@@ -14,7 +14,6 @@ initializeDataTables = (target) ->
       buttons: [
         {
           extend: 'colvis',
-          text: 'Show / Hide',
           postfixButtons: [
             { extend: 'colvisGroup', text: 'Show all', show: ':hidden', className: 'buttons-colvisGroup-first'},
             { extend: 'colvisGroup', text: 'Show none', hide: ':visible'}
@@ -49,7 +48,7 @@ initializeDataTables = (target) ->
       deferRender: true
       displayStart: datatable.data('display-start')
       iDisplayLength: datatable.data('display-length')
-      language: { 'lengthMenu': '&nbsp;with _MENU_ per page'}
+      language: { url: "/datatables/i18n/" + datatable.data('locale') }
       lengthMenu: [[5, 10, 25, 50, 100, 250, 500, 9999999], ['5', '10', '25', '50', '100', '250', '500', 'All']]
       order: datatable.data('display-order')
       processing: true

--- a/app/assets/javascripts/effective_datatables/initialize.js.coffee
+++ b/app/assets/javascripts/effective_datatables/initialize.js.coffee
@@ -48,7 +48,7 @@ initializeDataTables = (target) ->
       deferRender: true
       displayStart: datatable.data('display-start')
       iDisplayLength: datatable.data('display-length')
-      language: { url: "/datatables/i18n/" + datatable.data('locale') }
+      language: datatable.data('language')
       lengthMenu: [[5, 10, 25, 50, 100, 250, 500, 9999999], ['5', '10', '25', '50', '100', '250', '500', 'All']]
       order: datatable.data('display-order')
       processing: true

--- a/app/controllers/effective/datatables_controller.rb
+++ b/app/controllers/effective/datatables_controller.rb
@@ -2,6 +2,12 @@ module Effective
   class DatatablesController < ApplicationController
     skip_log_page_views quiet: true if defined?(EffectiveLogging)
 
+    LOCALES_PATH = File.join(Gem::Specification.find_by_name("effective_datatables").gem_dir, 'app', 'assets', 'javascripts', 'dataTables', 'locales')
+
+    AVAILABLE_LOCALES = Hash[
+      Dir["#{LOCALES_PATH}/*"].map { |locale| [File.basename(locale), locale] }
+    ]
+
     # This will respond to both a GET and a POST
     def show
       begin
@@ -54,6 +60,10 @@ module Effective
         render(status: :error, body: 'Unexpected Error')
       end
 
+    end
+
+    def i18n
+      render :json => JSON.parse(File.read(AVAILABLE_LOCALES[params[:language]] || AVAILABLE_LOCALES['en']))
     end
 
     private

--- a/app/controllers/effective/datatables_controller.rb
+++ b/app/controllers/effective/datatables_controller.rb
@@ -2,12 +2,6 @@ module Effective
   class DatatablesController < ApplicationController
     skip_log_page_views quiet: true if defined?(EffectiveLogging)
 
-    LOCALES_PATH = File.join(Gem::Specification.find_by_name("effective_datatables").gem_dir, 'app', 'assets', 'javascripts', 'dataTables', 'locales')
-
-    AVAILABLE_LOCALES = Hash[
-      Dir["#{LOCALES_PATH}/*"].map { |locale| [File.basename(locale), locale] }
-    ]
-
     # This will respond to both a GET and a POST
     def show
       begin
@@ -60,10 +54,6 @@ module Effective
         render(status: :error, body: 'Unexpected Error')
       end
 
-    end
-
-    def i18n
-      render :json => JSON.parse(File.read(AVAILABLE_LOCALES[params[:language]] || AVAILABLE_LOCALES['en']))
     end
 
     private

--- a/app/helpers/effective_datatables_helper.rb
+++ b/app/helpers/effective_datatables_helper.rb
@@ -56,7 +56,8 @@ module EffectiveDatatablesHelper
         'simple' => simple.to_s,
         'spinner' => icon('spinner'), # effective_bootstrap
         'source' => effective_datatables.datatable_path(datatable, {format: 'json'}),
-        'total-records' => datatable.to_json[:recordsTotal]
+        'total-records' => datatable.to_json[:recordsTotal],
+        'locale' => I18n.locale
       }
     }
 

--- a/app/helpers/effective_datatables_helper.rb
+++ b/app/helpers/effective_datatables_helper.rb
@@ -1,5 +1,10 @@
 # These are expected to be called by a developer.  They are part of the datatables DSL.
 module EffectiveDatatablesHelper
+  LOCALES_PATH = File.join(Gem::Specification.find_by_name("effective_datatables").gem_dir, 'app', 'assets', 'javascripts', 'dataTables', 'locales')
+
+  AVAILABLE_LOCALES = Hash[
+    Dir["#{LOCALES_PATH}/*"].map { |locale| [File.basename(locale), locale] }
+  ]
 
   def render_datatable(datatable, input_js: {}, buttons: true, charts: true, entries: true, filters: true, inline: false, pagination: true, search: true, simple: false, sort: true)
     raise 'expected datatable to be present' unless datatable
@@ -57,7 +62,7 @@ module EffectiveDatatablesHelper
         'spinner' => icon('spinner'), # effective_bootstrap
         'source' => effective_datatables.datatable_path(datatable, {format: 'json'}),
         'total-records' => datatable.to_json[:recordsTotal],
-        'locale' => I18n.locale
+        'language' => JSON.parse(File.read(AVAILABLE_LOCALES[I18n.locale.to_s] || AVAILABLE_LOCALES['en'])).to_json
       }
     }
 

--- a/app/helpers/effective_datatables_private_helper.rb
+++ b/app/helpers/effective_datatables_private_helper.rb
@@ -30,29 +30,29 @@ module EffectiveDatatablesPrivateHelper
   end
 
   def datatable_reset(datatable)
-    link_to(content_tag(:span, 'Reset'), '#', class: 'btn btn-link btn-sm buttons-reset-search')
+    link_to(content_tag(:span, t('effective_datatables.reset')), '#', class: 'btn btn-link btn-sm buttons-reset-search')
   end
 
   def datatable_reorder(datatable)
     return unless datatable.reorder? && EffectiveDatatables.authorized?(self, :update, datatable.collection_class)
-    link_to(content_tag(:span, 'Reorder'), '#', class: 'btn btn-link btn-sm buttons-reorder', disabled: true)
+    link_to(content_tag(:span, t('effective_datatables.reorder')), '#', class: 'btn btn-link btn-sm buttons-reorder', disabled: true)
   end
 
   def datatable_new_resource_button(datatable, name, column)
     return unless column[:inline] && (column[:actions][:new] != false) && (datatable.resource.actions.include?(:new) rescue false)
 
-    actions = {'New' => { action: :new, class: ['btn', column[:btn_class].presence].compact.join(' '), 'data-remote': true } }
+    actions = {t('effective_datatables.new') => { action: :new, class: ['btn', column[:btn_class].presence].compact.join(' '), 'data-remote': true } }
     render_resource_actions(datatable.resource.klass, actions: actions, effective_resource: datatable.resource) # Will only work if permitted
   end
 
   def datatable_label_tag(datatable, name, opts)
     case opts[:as]
     when :actions
-      content_tag(:span, 'Actions', style: 'display: none;')
+      content_tag(:span, t('effective_datatables.actions'), style: 'display: none;')
     when :bulk_actions
-      content_tag(:span, 'Bulk Actions', style: 'display: none;')
+      content_tag(:span, t('effective_datatables.bulk_actions'), style: 'display: none;')
     when :reorder
-      content_tag(:span, 'Reorder', style: 'display: none;')
+      content_tag(:span, t('effective_datatables.reorder'), style: 'display: none;')
     else
       content_tag(:span, opts[:label].presence)
     end

--- a/app/models/effective/effective_datatable/format.rb
+++ b/app/models/effective/effective_datatable/format.rb
@@ -74,8 +74,8 @@ module Effective
           (view.render_resource_actions(value, atts) || '')
         when :boolean
           case value
-          when true   ; 'Yes'
-          when false  ; 'No'
+          when true   ; I18n.t('effective_datatables.yes')
+          when false  ; I18n.t('effective_datatables.no')
           end
         when :currency
           view.number_to_currency(value)

--- a/app/views/effective/datatables/_filters.html.haml
+++ b/app/views/effective/datatables/_filters.html.haml
@@ -9,6 +9,6 @@
 
       .form-group.col-auto
         - if datatable._filters_form_required?
-          = form.save 'Apply', 'data-disable-with': 'Applying...'
+          = form.save t('effective_datatables.apply'), 'data-disable-with': t('effective_datatables.applying')
         - else
-          = link_to 'Apply', '#', class: 'btn btn-primary btn-effective-datatables-filters', 'data-apply-effective-datatables-filters': true
+          = link_to t('effective_datatables.apply'), '#', class: 'btn btn-primary btn-effective-datatables-filters', 'data-apply-effective-datatables-filters': true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  effective_datatables:
+    apply: Apply
+    reset: Reset
+    reorder: Reorder
+    new: New
+    actions: Actions
+    bulk_actions: Bulk Actions
+    applying: Applying...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,3 +8,5 @@ en:
     actions: Actions
     bulk_actions: Bulk Actions
     applying: Applying...
+    'yes': 'Yes'
+    'no': 'No'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  effective_datatables:
+    apply: Filtrar
+    reset: Reiniciar
+    reorder: Reordenar
+    new: Nuevo
+    actions: Acciones
+    bulk_actions: Acciones en masa
+    applying: Filtrando...

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -8,3 +8,5 @@ es:
     actions: Acciones
     bulk_actions: Acciones en masa
     applying: Filtrando...
+    'yes': 'Sí'
+    'no': 'No'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,12 @@
+---
+nl:
+  effective_datatables:
+    apply: Toepassen
+    reset: Reset
+    reorder: Opnieuw ordenen
+    new: Nieuwe
+    actions: Acties
+    bulk_actions: Bulkacties
+    applying: Toepassen...
+    'yes': 'Ja'
+    'no': 'Nee'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 EffectiveDatatables::Engine.routes.draw do
   scope :module => 'effective' do
+    get 'datatables/i18n/:language', to: 'datatables#i18n'
     match 'datatables/:id(.:format)', to: 'datatables#show', via: [:get, :post], as: :datatable
     match 'datatables/:id/reorder(.:format)', to: 'datatables#reorder', via: [:post], as: :reorder_datatable
   end


### PR DESCRIPTION
Hi there!

This PR adds support for multiple languages. 

I got all the locales from https://github.com/DataTables/Plugins/tree/master/i18n. And it should be fairly easy to keep it updated since they don't seem to change those in years 😆 . 

I added a script to rename all of those automatically. Most were renamed correctly:

https://github.com/code-and-effect/effective_datatables/compare/master...Nerian:i18n?expand=1#diff-44bc3deb2aac18ddfba9896b6f5deaa8

The integration works by:

1. Adding a new data option, the locale, to the effective-datatable initializer which takes the value from `I18n.locale`. 

2. Then datatables loads the right locale asynchronously – as per the docs https://datatables.net/plug-ins/i18n/ . It hits a new route ( https://github.com/code-and-effect/effective_datatables/compare/master...Nerian:i18n?expand=1#diff-21497849d8f00507c9c8dcaf6288b136R3
 )

3. The new action returns the right locale data.

https://github.com/code-and-effect/effective_datatables/compare/master...Nerian:i18n?expand=1#diff-e93e5a8bcde477bdb7e2f0d71dd44f94R66

It defaults to english in case there is not such a locale available.