### PR TITLE
bulk_download needs to be opts-aware

### DIFF
--- a/app/models/effective/effective_datatable/dsl/bulk_actions.rb
+++ b/app/models/effective/effective_datatable/dsl/bulk_actions.rb
@@ -7,8 +7,8 @@ module Effective
           datatable._bulk_actions.push(link_to_bulk_action(*args))
         end
 
-        def bulk_download(*args)
-          datatable._bulk_actions.push(link_to_bulk_action(*args.merge('data-authenticity-token' => form_authenticity_token, 'data-method' => :post)))
+        def bulk_download(body, url, opts = {})
+          datatable._bulk_actions.push(link_to_bulk_action(body, url, opts.merge('data-authenticity-token' => form_authenticity_token, 'data-method' => :post)))
         end
 
         def bulk_action_divider


### PR DESCRIPTION
def bulk_download(*args)
...
*args.merge(...)

^^ looks like a find-replace error to me.

I don't see any tests. Apologies if I missed them somewhere.