### PR TITLE
Make the length selector more visible

### DIFF
--- a/app/assets/stylesheets/effective_datatables/_overrides.scss
+++ b/app/assets/stylesheets/effective_datatables/_overrides.scss
@@ -189,17 +189,16 @@ table.dataTable.hide-buttons {
 
     // Apply custom style to the inline x per page select
     span.select2-container {
-      margin: 0px -3px 3px -3px;
+      margin: 0 1em;
       max-width: 6.0rem;
       min-width: 3.0rem;
 
-      .select2-selection { border: none; }
       .select2-selection__rendered { padding: 0em; color: #909090; }
     }
 
     span.select2-container.select2-container--open { min-width: 3.0rem; max-width: 6.0rem; }
     span.select2-container.select2-container--focus { border: none; box-shadow: none; }
-    span.select2-container--focus > .selection > .select2-selection { border: none !important; }
+    span.select2-selection.select2-selection--single:focus { outline: none; }
   }
 }
 


### PR DESCRIPTION
Hi,

This PR makes the length selector at the bottom of the table be more visible. I had an interview with one of my clients and they had no idea that was clickable 😭 So this should fix it.

Current:

<img width="520" alt="Captura de pantalla 2019-05-18 a las 15 51 46" src="https://user-images.githubusercontent.com/259568/57970710-e66c1e00-7984-11e9-8dac-bd91a3e9e656.png">

This PR:

<img width="579" alt="Captura de pantalla 2019-05-18 a las 15 50 51" src="https://user-images.githubusercontent.com/259568/57970712-e835e180-7984-11e9-8a14-c19857bed3c0.png">

What do you think?
