### PR TITLE
Handle autofocus on datatable render

### DIFF
--- a/app/assets/javascripts/effective_datatables/initialize.js.coffee
+++ b/app/assets/javascripts/effective_datatables/initialize.js.coffee
@@ -200,6 +200,7 @@ initializeDataTables = (target) ->
 
     table.addClass('initialized')
     table.children('thead').trigger('effective-bootstrap:initialize')
+    $('input[autofocus]').first().focus()
     true
 
 destroyDataTables = ->


### PR DESCRIPTION
Hi!

This PR adds support for autofocus attribute. Without this PR the autofocus will only work on load, but not when coming from another page via Turbolinks.

So what I did was adding a call to `$('input[autofocus]').first().focus()` on the `initializeDataTables` function.

So now you can do this:

```
class ContactsDatatable < Effective::Datatable
  datatable do
    col :name, search: { as: :text, autofocus: true }
  end

  collection do
    Contact.all
  end
end
```

And the input field is autofocused. 🎈 