### PR TITLE
Add support for bootstrap-5

### DIFF
--- a/app/helpers/effective_datatables_private_helper.rb
+++ b/app/helpers/effective_datatables_private_helper.rb
@@ -131,7 +131,7 @@ module EffectiveDatatablesPrivateHelper
       label: false,
       placeholder: (opts[:label] || name.to_s.titleize),
       value: value,
-      wrapper: { class: 'form-group col-auto'}
+      wrapper: { class: 'col-auto'}
     }.merge(opts.except(:as, :collection, :parse, :value))
 
     options[:name] = '' unless datatable._filters_form_required?
@@ -163,7 +163,7 @@ module EffectiveDatatablesPrivateHelper
       feedback: false,
       label: false,
       required: false,
-      wrapper: { class: 'form-group col-auto'}
+      wrapper: { class: 'col-auto'}
     }.merge(opts.except(:checked, :value))
 
     form.radios :scope, collection, options

--- a/app/views/effective/datatables/_bulk_actions_column.html.haml
+++ b/app/views/effective/datatables/_bulk_actions_column.html.haml
@@ -1,6 +1,6 @@
 - id = (resource.try(:to_param) || resource.try(:id) || resource.object_id)
 
-.form-group.custom-control.custom-checkbox
+.custom-control.custom-checkbox
   %input{value: 0, type: 'hidden'}
   %input.custom-control-input{name: "#{column[:input_name]}[]", id: "datatable_bulk_actions_resource_#{id}", value: id, type: 'checkbox', autocomplete: 'off', 'data-role': 'bulk-action' }
   %label.custom-control-label{for: "datatable_bulk_actions_resource_#{id}" }

--- a/app/views/effective/datatables/_bulk_actions_dropdown.html.haml
+++ b/app/views/effective/datatables/_bulk_actions_dropdown.html.haml
@@ -1,5 +1,5 @@
 .btn-group.buttons-bulk-actions
-  %button.btn.btn-link.btn-sm.dropdown-toggle{'type': 'button', 'data-toggle': 'dropdown', 'aria-haspopup': true, 'aria-expanded': false, 'disabled': 'disabled'}
+  %button.btn.btn-link.btn-sm.dropdown-toggle{'type': 'button', 'data-toggle': 'dropdown', 'data-bs-toggle': 'dropdown', 'aria-haspopup': true, 'aria-expanded': false, 'disabled': 'disabled'}
     = t('effective_datatables.bulk_actions')
   .dropdown-menu
     - if datatable._bulk_actions.present?

--- a/app/views/effective/datatables/_filters.html.haml
+++ b/app/views/effective/datatables/_filters.html.haml
@@ -1,13 +1,13 @@
 .effective-datatables-filters{'aria-controls': datatable.to_param}
   = effective_form_with(scope: :filters, url: (datatable._form[:url] || '#'), method: datatable._form[:verb], id: nil) do |form|
-    .form-row.align-items-center
+    .row.g-3
       - if datatable._scopes.present?
         = datatable_scope_tag(form, datatable)
 
       - datatable._filters.each do |name, opts|
         = datatable_filter_tag(form, datatable, name, opts)
 
-      .form-group.col-auto
+      .col-auto
         - if datatable._filters_form_required?
           = form.save t('effective_datatables.apply'), 'data-disable-with': t('effective_datatables.applying')
         - else


### PR DESCRIPTION
Howdy!

I am updating my apps to Bootstrap 5. And noticed that the filters appear off in B5.

So this PR adds support for Bootstrap 5.

After these changes, when using Bootstrap 4 this looks like this:

![Screenshot 2021-06-15 at 18 26 37](https://user-images.githubusercontent.com/259568/122094421-76068400-ce0c-11eb-8d78-f0174bc78f07.png)

After these changes, when using Bootstrap 5 it looks like this:

![Screenshot 2021-06-15 at 19 04 25](https://user-images.githubusercontent.com/259568/122094525-8fa7cb80-ce0c-11eb-8f08-8720e7d57825.png)

Using Bootstrap 5 but without the changes in this PR looks like this:

![Screenshot 2021-06-15 at 19 06 20](https://user-images.githubusercontent.com/259568/122094755-cc73c280-ce0c-11eb-913a-2bccc5135954.png)


---

https://getbootstrap.com/docs/5.0/migration/