### PR TITLE
Add support for ruby 3.1 keyword arguments

### DIFF
--- a/app/models/effective/datatable_dsl_tool.rb
+++ b/app/models/effective/datatable_dsl_tool.rb
@@ -18,7 +18,7 @@ module Effective
       @view = datatable.view
     end
 
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       # Catch a common error
       if [:bulk_actions, :charts, :collection, :filters].include?(method) && in_datatables_do_block
         raise "#{method} block must be declared outside the datatable do ... end block"
@@ -26,15 +26,15 @@ module Effective
 
       if datatable.respond_to?(method)
         if block_given?
-          datatable.send(method, *args) { yield }
+          datatable.send(method, *args, **kwargs) { yield }
         else
-          datatable.send(method, *args)
+          datatable.send(method, *args, **kwargs)
         end
       elsif view.respond_to?(method)
         if block_given?
-          view.send(method, *args) { yield }
+          view.send(method, *args, **kwargs) { yield }
         else
-          view.send(method, *args)
+          view.send(method, *args, **kwargs)
         end
       else
         super

--- a/app/models/effective/effective_datatable/dsl/bulk_actions.rb
+++ b/app/models/effective/effective_datatable/dsl/bulk_actions.rb
@@ -36,7 +36,7 @@ module Effective
 
           opts[:class] = [opts[:class], 'dropdown-item'].compact.join(' ')
 
-          link_to(title, url, opts)
+          link_to(title, url, **opts)
         end
 
       end


### PR DESCRIPTION
Hello,

This PR adds support for Ruby 3 keyword arguments. 

Without this I get an error:

```
Failure/Error: l(charge.date, format: :long)

     ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/datatable_dsl_tool.rb:37:in `method_missing'
     # ./app/datatable/charges_datatable.rb:16:in `block (2 levels) in <class:ChargesDatatable>'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:71:in `instance_exec'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:71:in `block (2 levels) in format'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:57:in `each'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:57:in `block in format'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:56:in `each'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:56:in `each_with_index'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/format.rb:56:in `format'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/effective_datatable/compute.rb:57:in `compute'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/datatable.rb:153:in `to_json'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/helpers/effective_datatables_helper.rb:60:in `render_datatable'
     # ./app/views/invoicing/invoices/show.html.slim:37:in `_app_views_invoicing_invoices_show_html_slim___3251406276111731776_151720'
     # <internal:kernel>:90:in `tap'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/actiontext-7.0.2.3/lib/action_text/rendering.rb:20:in `with_renderer'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/actiontext-7.0.2.3/lib/action_text/engine.rb:69:in `block (4 levels) in <class:Engine>'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/conditional_get.rb:27:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/railties-7.0.2.3/lib/rails/rack/logger.rb:36:in `call_app'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/railties-7.0.2.3/lib/rails/rack/logger.rb:25:in `block in call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/railties-7.0.2.3/lib/rails/rack/logger.rb:25:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/lock.rb:18:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/railties-7.0.2.3/lib/rails/engine.rb:530:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/urlmap.rb:74:in `block in call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/urlmap.rb:58:in `each'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/urlmap.rb:58:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/capybara-3.36.0/lib/capybara/server/middleware.rb:60:in `call'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/rack-2.2.3/lib/rack/handler/webrick.rb:95:in `service'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/webrick-1.7.0/lib/webrick/httpserver.rb:140:in `service'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/webrick-1.7.0/lib/webrick/httpserver.rb:96:in `run'
     # /Users/Nerian/.rvm/gems/ruby-3.1.1/gems/webrick-1.7.0/lib/webrick/server.rb:310:in `block in start_thread'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 2, expected 1)
     #   /Users/Nerian/.rvm/gems/ruby-3.1.1/bundler/gems/effective_datatables-af437695ac85/app/models/effective/datatable_dsl_tool.rb:37:in `method_missing'
```

For code like this:

```
    col :date, label: I18n.t('general.date') do |charge|
      l(charge.date, format: :long)
    end
```