### PR TITLE
Allow previous New button class in Datatables

### DIFF
--- a/app/helpers/effective_datatables_private_helper.rb
+++ b/app/helpers/effective_datatables_private_helper.rb
@@ -44,8 +44,8 @@ module EffectiveDatatablesPrivateHelper
   def datatable_new_resource_button(datatable, name, column)
     return unless datatable.inline? && (column[:actions][:new] != false)
 
-    # Override the default btn_class and use this one
-    action = { action: :new, class: 'btn btn-sm btn-success', 'data-remote': true }
+    btn_class = EffectiveDatatables.new_action_button_class || 'btn-success'
+    action = { action: :new, class: "btn #{btn_class}", 'data-remote': true }
 
     if column[:actions][:new].kind_of?(Hash) # This might be active_record_array_collection?
       actions = action.merge(column[:actions][:new])

--- a/app/models/effective/effective_datatable/dsl/datatable.rb
+++ b/app/models/effective/effective_datatable/dsl/datatable.rb
@@ -101,7 +101,7 @@ module Effective
             action: false,
             as: :actions,
             compute: nil,
-            btn_class: (btn_class || 'btn-sm btn-outline-primary'),
+            btn_class: (btn_class || EffectiveDatatables.default_button_class || 'btn-outline-primary'),
             col_class: col_class,
             csv: false,
             format: (format if block_given?),

--- a/config/effective_datatables.rb
+++ b/config/effective_datatables.rb
@@ -30,6 +30,10 @@ EffectiveDatatables.setup do |config|
   # Default class used on the <table> tag
   config.html_class = 'table table-hover'
 
+  # These are the button classes
+  # config.default_button_class = 'btn-outline-primary' # default class when btn_class option is unspecified
+  # config.new_action_button_class = 'btn-success' # overriding class on new action
+
   # Log search/sort information to the console
   config.debug = true
 

--- a/lib/effective_datatables.rb
+++ b/lib/effective_datatables.rb
@@ -12,6 +12,8 @@ module EffectiveDatatables
   mattr_accessor :length_menu
 
   mattr_accessor :html_class
+  mattr_accessor :default_button_class
+  mattr_accessor :new_action_button_class
   mattr_accessor :save_state
 
   mattr_accessor :cookie_max_size


### PR DESCRIPTION
Added configuration to let me revert New button to the old style (new buttons used to be 'btn-outline-primary' before commit 4f32e59); also remove redundant 'btn-sm' class