### PR TITLE
fix typo from commit 9b10064

### DIFF
--- a/app/helpers/effective_datatables_private_helper.rb
+++ b/app/helpers/effective_datatables_private_helper.rb
@@ -48,7 +48,7 @@ module EffectiveDatatablesPrivateHelper
     action = { action: :new, class: "btn #{btn_class}", 'data-remote': true }
 
     if column[:actions][:new].kind_of?(Hash) # This might be active_record_array_collection?
-      actions = action.merge(column[:actions][:new])
+      action = action.merge(column[:actions][:new])
 
       effective_resource = (datatable.effective_resource || datatable.fallback_effective_resource)
       klass = (column[:actions][:new][:klass] || effective_resource&.klass || datatable.collection_class)


### PR DESCRIPTION
`actions` looks like an accidental typo (as the singular `action` makes more sense as this represents a singular action, which is used later in a hash of actions.)

(I'm guessing you're trying to remove `merge!` where the hash update was unnecessary. However, in that line, `merge!` seems appropriate.)